### PR TITLE
[Feat] 의존성 주입, Sample API 호출 로직 구현

### DIFF
--- a/Projects/App/Sources/DI.swift
+++ b/Projects/App/Sources/DI.swift
@@ -1,0 +1,20 @@
+//
+//  DI.swift
+//  Darayo
+//
+//  Created by 이정원 on 6/9/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Dependencies
+import Domain
+import Data
+import Network
+
+extension NetworkServiceKey: @retroactive DependencyKey {
+    public static let liveValue: NetworkServiceProtocol = NetworkService()
+}
+
+extension SampleRepositoryKey: @retroactive DependencyKey {
+    public static let liveValue: SampleRepositoryProtocol = SampleRepository()
+}

--- a/Projects/App/Sources/DarayoApp.swift
+++ b/Projects/App/Sources/DarayoApp.swift
@@ -7,12 +7,17 @@
 //
 
 import SwiftUI
+import Root
 
 @main
 struct DarayoApp: App {
     var body: some Scene {
         WindowGroup {
-            Text("Hello World!")
+            RootView(
+                store: .init(initialState: .init()) {
+                    RootFeature()
+                }
+            )
         }
     }
 }

--- a/Projects/Data/Sources/Endpoints/Endpoint.swift
+++ b/Projects/Data/Sources/Endpoints/Endpoint.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol Endpoint {
-    var baseURL: URL { get }
+    var baseURL: String { get }
     var path: String { get }
     var method: HTTPMethod { get }
     var headers: [String: String] { get }
@@ -23,4 +23,16 @@ public enum HTTPMethod: String {
     case put
     case patch
     case delete
+}
+
+extension Endpoint {
+    var baseURL: String {
+        // TODO: need to implement base url later.
+        return "https://api.sampleapis.com"
+    }
+    
+    var headers: [String: String] {
+        // TODO: need to implement header later.
+        return [:]
+    }
 }

--- a/Projects/Data/Sources/Endpoints/Endpoint.swift
+++ b/Projects/Data/Sources/Endpoints/Endpoint.swift
@@ -1,0 +1,26 @@
+//
+//  Endpoint.swift
+//  Data
+//
+//  Created by 이정원 on 6/6/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Foundation
+
+public protocol Endpoint {
+    var baseURL: URL { get }
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var headers: [String: String] { get }
+    var queryParameters: Encodable? { get }
+    var body: Encodable? { get }
+}
+
+public enum HTTPMethod: String {
+    case get
+    case post
+    case put
+    case patch
+    case delete
+}

--- a/Projects/Data/Sources/Endpoints/SampleEndpoint.swift
+++ b/Projects/Data/Sources/Endpoints/SampleEndpoint.swift
@@ -1,0 +1,15 @@
+//
+//  SampleEndpoint.swift
+//  Data
+//
+//  Created by 이정원 on 6/9/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+enum SampleEndpoint: Endpoint {
+    case coffee
+    var path: String { "coffee/iced" }
+    var method: HTTPMethod { .get }
+    var queryParameters: Encodable? { nil }
+    var body: Encodable? { nil }
+}

--- a/Projects/Data/Sources/NetworkError/NetworkError.swift
+++ b/Projects/Data/Sources/NetworkError/NetworkError.swift
@@ -1,12 +1,10 @@
 //
 //  NetworkError.swift
-//  Network
+//  Data
 //
 //  Created by 이정원 on 6/6/25.
 //  Copyright © 2025 Darayo. All rights reserved.
 //
-
-import Foundation
 
 public struct NetworkError: Error {
     public let type: ErrorType

--- a/Projects/Data/Sources/Repositories/SampleRepository.swift
+++ b/Projects/Data/Sources/Repositories/SampleRepository.swift
@@ -1,0 +1,20 @@
+//
+//  SampleRepository.swift
+//  Data
+//
+//  Created by 이정원 on 6/9/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Domain
+import Dependencies
+
+public struct SampleRepository: SampleRepositoryProtocol {
+    @Dependency(\.networkService) private var networkService
+    
+    public init() {}
+    
+    public func helloWorld() {
+        print("Hello World!")
+    }
+}

--- a/Projects/Data/Sources/Repositories/SampleRepository.swift
+++ b/Projects/Data/Sources/Repositories/SampleRepository.swift
@@ -11,10 +11,11 @@ import Dependencies
 
 public struct SampleRepository: SampleRepositoryProtocol {
     @Dependency(\.networkService) private var networkService
-    
     public init() {}
     
-    public func helloWorld() {
-        print("Hello World!")
+    public func fetchCoffeeList() async throws -> [Coffee] {
+        let endpoint = SampleEndpoint.coffee
+        let response: [CoffeeResponse] = try await networkService.request(endpoint: endpoint)
+        return response.compactMap { $0.toDomain }
     }
 }

--- a/Projects/Data/Sources/Responses/CoffeeResponse.swift
+++ b/Projects/Data/Sources/Responses/CoffeeResponse.swift
@@ -1,0 +1,28 @@
+//
+//  CoffeeResponse.swift
+//  Data
+//
+//  Created by 이정원 on 6/9/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Domain
+
+struct CoffeeResponse: Decodable {
+    let id: Int?
+    let title: String?
+    let description: String?
+    let image: String?
+}
+
+extension CoffeeResponse {
+    var toDomain: Coffee? {
+        guard let id else { return nil }
+        return .init(
+            id: id,
+            title: title ?? "",
+            description: description ?? "",
+            imageURLString: image ?? ""
+        )
+    }
+}

--- a/Projects/Data/Sources/ServiceProtocols/NetworkServiceProtocol.swift
+++ b/Projects/Data/Sources/ServiceProtocols/NetworkServiceProtocol.swift
@@ -1,0 +1,28 @@
+//
+//  NetworkServiceProtocol.swift
+//  Data
+//
+//  Created by 이정원 on 6/9/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Dependencies
+import Util
+
+public protocol NetworkServiceProtocol {
+    func request(endpoint: Endpoint) async throws
+    func request<Response: Decodable>(endpoint: Endpoint) async throws -> Response
+}
+
+public enum NetworkServiceKey: TestDependencyKey {
+    public static var testValue: NetworkServiceProtocol {
+        unimplemented(NetworkServiceProtocol.self)
+    }
+}
+
+extension DependencyValues {
+    var networkService: NetworkServiceProtocol {
+        get { self[NetworkServiceKey.self] }
+        set { self[NetworkServiceKey.self] = newValue }
+    }
+}

--- a/Projects/Domain/Sources/Models/Coffee.swift
+++ b/Projects/Domain/Sources/Models/Coffee.swift
@@ -1,0 +1,26 @@
+//
+//  Coffee.swift
+//  Domain
+//
+//  Created by 이정원 on 6/9/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+public struct Coffee {
+    public let id: Int
+    public let title: String
+    public let description: String
+    public let imageURLString: String
+    
+    public init(
+        id: Int,
+        title: String,
+        description: String,
+        imageURLString: String
+    ) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.imageURLString = imageURLString
+    }
+}

--- a/Projects/Domain/Sources/RepositoryProtocols/SampleRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/RepositoryProtocols/SampleRepositoryProtocol.swift
@@ -9,13 +9,11 @@
 import Dependencies
 
 public protocol SampleRepositoryProtocol {
-    func helloWorld()
+    func fetchCoffeeList() async throws -> [Coffee]
 }
 
 private struct MockSampleRepository: SampleRepositoryProtocol {
-    func helloWorld() {
-        print("Hello World! (Mock)")
-    }
+    func fetchCoffeeList() async throws -> [Coffee] { [] }
 }
 
 public enum SampleRepositoryKey: TestDependencyKey {

--- a/Projects/Domain/Sources/RepositoryProtocols/SampleRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/RepositoryProtocols/SampleRepositoryProtocol.swift
@@ -1,0 +1,30 @@
+//
+//  SampleRepositoryProtocol.swift
+//  Domain
+//
+//  Created by 이정원 on 6/8/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Dependencies
+
+public protocol SampleRepositoryProtocol {
+    func helloWorld()
+}
+
+private struct MockSampleRepository: SampleRepositoryProtocol {
+    func helloWorld() {
+        print("Hello World! (Mock)")
+    }
+}
+
+public enum SampleRepositoryKey: TestDependencyKey {
+    public static let testValue: SampleRepositoryProtocol = MockSampleRepository()
+}
+
+extension DependencyValues {
+    var sampleRepository: SampleRepositoryProtocol {
+        get { self[SampleRepositoryKey.self] }
+        set { self[SampleRepositoryKey.self] = newValue }
+    }
+}

--- a/Projects/Domain/Sources/UseCases/SampleUseCase.swift
+++ b/Projects/Domain/Sources/UseCases/SampleUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  SampleUseCase.swift
+//  Domain
+//
+//  Created by 이정원 on 6/8/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Dependencies
+
+public struct SampleUseCase {
+    @Dependency(\.sampleRepository) private var sampleRepository
+    
+    public func helloWorld() {
+        sampleRepository.helloWorld()
+    }
+}
+
+private enum SampleUseCaseKey: DependencyKey {
+    public static let liveValue = SampleUseCase()
+}
+
+public extension DependencyValues {
+    var sampleUseCase: SampleUseCase {
+        get { self[SampleUseCaseKey.self] }
+        set { self[SampleUseCaseKey.self] = newValue }
+    }
+}

--- a/Projects/Domain/Sources/UseCases/SampleUseCase.swift
+++ b/Projects/Domain/Sources/UseCases/SampleUseCase.swift
@@ -11,8 +11,8 @@ import Dependencies
 public struct SampleUseCase {
     @Dependency(\.sampleRepository) private var sampleRepository
     
-    public func helloWorld() {
-        sampleRepository.helloWorld()
+    public func fetchCoffeeList() async throws -> [Coffee] {
+        return try await sampleRepository.fetchCoffeeList()
     }
 }
 

--- a/Projects/Features/Root/Sources/RootFeature.swift
+++ b/Projects/Features/Root/Sources/RootFeature.swift
@@ -1,0 +1,34 @@
+//
+//  RootFeature.swift
+//  Root
+//
+//  Created by 이정원 on 6/8/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import ComposableArchitecture
+import Domain
+
+@Reducer
+public struct RootFeature {
+    @Dependency(\.sampleUseCase) private var sampleUseCase
+    
+    public struct State {
+        public init() {}
+    }
+    
+    public enum Action {
+        case onAppear
+    }
+    
+    public init() {}
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                sampleUseCase.helloWorld()
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Features/Root/Sources/RootFeature.swift
+++ b/Projects/Features/Root/Sources/RootFeature.swift
@@ -13,12 +13,18 @@ import Domain
 public struct RootFeature {
     @Dependency(\.sampleUseCase) private var sampleUseCase
     
+    @ObservableState
     public struct State {
+        var isLoading: Bool = false
+        var coffeeList: [Coffee] = []
+        var errorMessage: String = ""
         public init() {}
     }
     
     public enum Action {
         case onAppear
+        case coffeeListFetched([Coffee])
+        case showError(Error)
     }
     
     public init() {}
@@ -26,9 +32,28 @@ public struct RootFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                sampleUseCase.helloWorld()
+                state.isLoading = true
+                return .run { send in await send(fetchCoffeeList()) }
+            case .coffeeListFetched(let coffeeList):
+                state.coffeeList = coffeeList
+                state.isLoading = false
+                return .none
+            case .showError(let error):
+                state.errorMessage = error.localizedDescription
+                state.isLoading = false
                 return .none
             }
+        }
+    }
+}
+
+private extension RootFeature {
+    func fetchCoffeeList() async -> Action {
+        do {
+            let coffeeList = try await sampleUseCase.fetchCoffeeList()
+            return .coffeeListFetched(coffeeList)
+        } catch {
+            return .showError(error)
         }
     }
 }

--- a/Projects/Features/Root/Sources/RootView.swift
+++ b/Projects/Features/Root/Sources/RootView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import ComposableArchitecture
+import Domain
 
 public struct RootView: View {
     private let store: StoreOf<RootFeature>
@@ -17,7 +18,73 @@ public struct RootView: View {
     }
     
     public var body: some View {
-        Text("RootView")
-            .onAppear { store.send(.onAppear) }
+        ZStack {
+            NavigationStack {
+                ScrollView {
+                    coffeeListView
+                }
+                .navigationTitle("Coffee")
+            }
+            
+            if store.isLoading {
+                ProgressView()
+            }
+        }
+        .onAppear { store.send(.onAppear) }
+    }
+}
+
+private extension RootView {
+    var titleView: some View {
+        Text("Coffee")
+            .font(.system(.title))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+    }
+    
+    var coffeeListView: some View {
+        LazyVStack(spacing: 0) {
+            ForEach(0..<store.coffeeList.count, id: \.self) { index in
+                let coffee = store.coffeeList[index]
+                VStack(spacing: 0) {
+                    coffeeView(coffee: coffee)
+                    if index < store.coffeeList.count - 1 {
+                        divider
+                    }
+                }
+            }
+        }
+    }
+    
+    func coffeeView(coffee: Coffee) -> some View {
+        HStack(alignment: .top, spacing: 20) {
+            AsyncImage(url: URL(string: coffee.imageURLString)) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+            } placeholder: {
+                Color.gray.opacity(0.2)
+            }
+            .frame(width: 80, height: 80)
+            .clipShape(Circle())
+                        
+            VStack(spacing: 8) {
+                Text(coffee.title)
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                
+                Text(coffee.description)
+                    .font(.system(size: 14, weight: .regular))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        
+        .padding(20)
+    }
+    
+    var divider: some View {
+        Color.gray.opacity(0.2)
+            .frame(maxWidth: .infinity)
+            .frame(height: 1)
     }
 }

--- a/Projects/Features/Root/Sources/RootView.swift
+++ b/Projects/Features/Root/Sources/RootView.swift
@@ -1,0 +1,23 @@
+//
+//  RootView.swift
+//  Root
+//
+//  Created by 이정원 on 6/8/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+public struct RootView: View {
+    private let store: StoreOf<RootFeature>
+    
+    public init(store: StoreOf<RootFeature>) {
+        self.store = store
+    }
+    
+    public var body: some View {
+        Text("RootView")
+            .onAppear { store.send(.onAppear) }
+    }
+}

--- a/Projects/Network/Sources/Endpoint.swift
+++ b/Projects/Network/Sources/Endpoint.swift
@@ -10,17 +10,6 @@ import Foundation
 import Data
 
 extension Endpoint {
-    var baseURL: String {
-        // TODO: need to implement base url later.
-        return ""
-    }
-    
-    var headers: [String: String] {
-        // TODO: need to implement header later.
-        // TODO: the token also needs to be considered later.
-        return [:]
-    }
-    
     var urlRequest: URLRequest {
         get throws {
             guard var url = URL(string: baseURL) else {

--- a/Projects/Network/Sources/Endpoint.swift
+++ b/Projects/Network/Sources/Endpoint.swift
@@ -7,23 +7,7 @@
 //
 
 import Foundation
-
-public protocol Endpoint {
-    var baseURL: URL { get }
-    var path: String { get }
-    var method: HTTPMethod { get }
-    var headers: [String: String] { get }
-    var queryParameters: Encodable? { get }
-    var body: Encodable? { get }
-}
-
-public enum HTTPMethod: String {
-    case get
-    case post
-    case put
-    case patch
-    case delete
-}
+import Data
 
 extension Endpoint {
     var baseURL: String {

--- a/Projects/Network/Sources/NetworkService.swift
+++ b/Projects/Network/Sources/NetworkService.swift
@@ -34,7 +34,7 @@ public struct NetworkService: NetworkServiceProtocol {
 private extension NetworkService {
     var urlSession: URLSession {
         let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = 10
+        configuration.timeoutIntervalForRequest = 20
         return .init(configuration: configuration)
     }
     

--- a/Projects/Network/Sources/NetworkService.swift
+++ b/Projects/Network/Sources/NetworkService.swift
@@ -7,13 +7,11 @@
 //
 
 import Foundation
-
-public protocol NetworkServiceProtocol {
-    func request(endpoint: Endpoint) async throws
-    func request<Response: Decodable>(endpoint: Endpoint) async throws -> Response
-}
+import Data
 
 public struct NetworkService: NetworkServiceProtocol {
+    public init() {}
+    
     public func request(endpoint: Endpoint) async throws {
         try await performRequest(endpoint: endpoint)
     }

--- a/Projects/Util/Sources/Extensions/TestDependencyKey+.swift
+++ b/Projects/Util/Sources/Extensions/TestDependencyKey+.swift
@@ -1,0 +1,15 @@
+//
+//  TestDependencyKey+.swift
+//  Util
+//
+//  Created by 이정원 on 6/9/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Dependencies
+
+public extension TestDependencyKey {
+    static func unimplemented<T>(_ type: T.Type) -> Never {
+        fatalError("\(type) is not implemented.")
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Dependency.swift
+++ b/Tuist/ProjectDescriptionHelpers/Dependency.swift
@@ -9,15 +9,17 @@ import ProjectDescription
 
 extension Module {
     private static let dependencyInfo: [Module: [Module]] = [
-        .app: [.feature(.root), .data],
+        .app: [.feature(.root), .network],
         .feature(.root): [.feature(.base)],
         .feature(.base): [.domain, .designSystem],
         .domain: [.util],
-        .data: [.domain, .network]
+        .data: [.domain],
+        .network: [.data]
     ]
     
     private static let externalDependencyInfo: [Module: [ExternalModule]] = [
-        .feature(.base): [.composableArchitecture]
+        .feature(.base): [.composableArchitecture],
+        .util: [.dependencies]
     ]
     
     private var path: Path {

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -51,6 +51,7 @@ public enum FeatureModule: Sendable {
 
 public enum ExternalModule: Sendable {
     case composableArchitecture
+    case dependencies
     
     public var name: String {
         "\(self)".capitalized

--- a/Tuist/ProjectDescriptionHelpers/ProjectInfo.swift
+++ b/Tuist/ProjectDescriptionHelpers/ProjectInfo.swift
@@ -9,7 +9,7 @@ import ProjectDescription
 
 public enum ProjectInfo {
     public static let organizationName: String = "Darayo"
-    public static let appName: String = "Darayo"
+    public static let appName: String = "Festibee"
     public static let destinations: Destinations = .iOS
     public static let deploymentTargets: DeploymentTargets = .iOS("17.0")
 }

--- a/Tuist/ProjectDescriptionHelpers/Target.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target.swift
@@ -14,6 +14,7 @@ public extension Target {
             destinations: ProjectInfo.destinations,
             product: module.product,
             bundleId: module.bundleID,
+            deploymentTargets: ProjectInfo.deploymentTargets,
             infoPlist: module.infoPlist,
             sources: module.sources,
             resources: module.resources,


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호를 명시하세요 (예: Closes #123, Resolves #45) -->
- #5

---

## ✨ 작업 내용
<!-- 어떤 기능/버그/리팩토링 작업을 했는지 간단하게 작성해주세요 -->
- TCA 안에 포함되어 있는 Swift Dependencies를 이용해 의존성을 주입하였습니다.
- UseCase는 별도의 Protocol을 설계하지 않았고, 의존성 관계가 역전되도록 UseCase가 Repository의 Protocol에, Repository가 NetworkService의 Protocol에 의존하게 만들었습니다.
- 이에 따라 Network 모듈이 Data 모듈에 의존하게 설정하였습니다.
- Repository와 NetworkService의 구현체를 주입하는 부분은 App 모듈에서 구현하였습니다.
- 설계한 Newtork 모듈이 잘 동작하는지 확인하기 위해 
https://sampleapis.com 에서 제공하는 Sample API를 호출하는 로직과 커피 리스트를 보여주는 UI를 구현하였습니다.
    - 추후에 API 호출 로직을 구현할 때 참고하면 좋을 것 같습니다.
    - 구현한 내용은 추후에 제거하겠습니다.

---

## 📸 Showcase
<!-- UI 변경이 있는 경우, 캡처 이미지나 GIF를 첨부해주세요 -->
<img src="https://github.com/user-attachments/assets/f9f1bf1f-fa97-42a6-ba64-693e7a754b3a"  width="400" />

---

## 📝 참고 사항
<!-- 리뷰어가 이해를 돕기 위한 추가 설명이나 논의 사항이 있다면 여기에 작성하세요 -->
- #2 , #4 PR이 merge되면 target branch를 변경하겠습니다.

