### PR TITLE
[Feat] Timetable UI 구현

### DIFF
--- a/Projects/DesignSystem/Demo/Sources/DesignSystemDemoApp.swift
+++ b/Projects/DesignSystem/Demo/Sources/DesignSystemDemoApp.swift
@@ -30,6 +30,10 @@ private extension DesignSystemDemoApp {
             NavigationLink("Icon Button") {
                 IconButtonDemoView()
             }
+            
+            NavigationLink("Timetable") {
+                TimetableDemoView()
+            }
         }
         .navigationTitle("Design System")
     }

--- a/Projects/DesignSystem/Demo/Sources/TimetableDemoView.swift
+++ b/Projects/DesignSystem/Demo/Sources/TimetableDemoView.swift
@@ -1,0 +1,72 @@
+//
+//  TimetableDemoView.swift
+//  DesignSystemDemo
+//
+//  Created by 이정원 on 6/16/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import SwiftUI
+import DesignSystem
+
+struct TimetableDemoView: View {
+    @State private var columnCount: Int = 1
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            button
+            TimetableView(timetable: timetable)
+        }
+        .background(Color.background1)
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarBackground(Color.background1, for: .navigationBar)
+    }
+}
+
+private extension TimetableDemoView {
+    var button: some View {
+        Button {
+            columnCount = columnCount % 4 + 1
+        } label: {
+            Text("Stage 개수 변경")
+                .pretendard(style: .title4)
+                .foregroundStyle(Color.white)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 48)
+        .background(Color.grey6)
+    }
+    
+    var timetable: Timetable {
+        Timetable(stages: stages, schedules: schedules)
+    }
+    
+    var stages: [String] {
+        let alphabets: [String] = ["A", "B", "C", "D"]
+        
+        return (0..<columnCount).map {
+            return "\(alphabets[$0]) stage"
+        }
+    }
+    
+    var schedules: [[Timetable.Schedule]] {
+        (0..<columnCount).map {
+            makeOneDaySchedule(column: $0)
+        }
+    }
+    
+    func makeOneDaySchedule(column: Int) -> [Timetable.Schedule] {
+        var base = 840
+        if column % 2 == 0 { base += 30 }
+        
+        return (0..<6).map { index in
+            let start = base + 90 * index
+            let end = start + 60
+            return .init(
+                start: .init(value: start),
+                end: .init(value: end),
+                artistName: "아티스트명"
+            )
+        }
+    }
+}

--- a/Projects/DesignSystem/Sources/Timetable/StageHeaderView.swift
+++ b/Projects/DesignSystem/Sources/Timetable/StageHeaderView.swift
@@ -1,0 +1,43 @@
+//
+//  StageHeaderView.swift
+//  DesignSystem
+//
+//  Created by 이정원 on 6/17/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import SwiftUI
+
+struct StageHeaderView: View {
+    private let stages: [String]
+    
+    init(stages: [String]) {
+        self.stages = stages
+    }
+    
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(0..<stages.count, id: \.self) { index in
+                let stage = stages[index]
+                
+                if stages.count > 3 {
+                    stageview(stage: stage)
+                        .frame(width: 86)
+                } else {
+                    stageview(stage: stage)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+        }
+        .padding(.horizontal, 8)
+    }
+}
+
+private extension StageHeaderView {
+    func stageview(stage: String) -> some View {
+        Text(stage)
+            .pretendard(style: .body4)
+            .foregroundStyle(Color.white)
+            .frame(height: 34)
+    }
+}

--- a/Projects/DesignSystem/Sources/Timetable/TimeHeaderView.swift
+++ b/Projects/DesignSystem/Sources/Timetable/TimeHeaderView.swift
@@ -1,0 +1,38 @@
+//
+//  TimeHeaderView.swift
+//  DesignSystem
+//
+//  Created by 이정원 on 6/17/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import SwiftUI
+
+struct TimeHeaderView: View {
+    private let start: Int
+    private let end: Int
+    
+    init(start: Int, end: Int) {
+        self.start = start
+        self.end = end
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(start..<end, id: \.self) { hour in
+                VStack(spacing: 2) {
+                    Color.grey6
+                        .frame(width: 20, height: 1)
+                    
+                    Text("\(String(format: "%02d", hour)):00")
+                        .pretendard(style: .caption2)
+                        .foregroundStyle(Color.white)
+                    
+                    Spacer()
+                }
+                .frame(width: 50, height: 96)
+            }
+        }
+        .padding(.top, 1)
+    }
+}

--- a/Projects/DesignSystem/Sources/Timetable/Timetable.swift
+++ b/Projects/DesignSystem/Sources/Timetable/Timetable.swift
@@ -1,0 +1,71 @@
+//
+//  Timetable.swift
+//  DesignSystem
+//
+//  Created by 이정원 on 6/19/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+public struct Timetable {
+    let stages: [String]
+    let schedules: [[Schedule]]
+    
+    public init(
+        stages: [String],
+        schedules: [[Schedule]]
+    ) {
+        self.stages = stages
+        self.schedules = schedules
+    }
+}
+
+extension Timetable {
+    public struct Schedule {
+        let start: Time
+        let end: Time
+        let artistName: String
+        
+        public init(
+            start: Time,
+            end: Time,
+            artistName: String
+        ) {
+            self.start = start
+            self.end = end
+            self.artistName = artistName
+        }
+    }
+}
+
+extension Timetable {
+    public struct Time {
+        let value: Int
+        
+        public init(value: Int) {
+            self.value = value
+        }
+        
+        public init(hour: Int, minute: Int) {
+            self.value = hour * 60 + minute
+        }
+        
+        var hour: Int { value / 60 }
+        var minute: Int { value % 60 }
+    }
+}
+
+extension [[Timetable.Schedule]] {
+    var start: Timetable.Time {
+        let value = compactMap { $0.first?.start.value }.min()
+        guard let value else { return .init(hour: 9, minute: 0) }
+        let time = Timetable.Time(value: value)
+        return .init(hour: time.hour, minute: 0)
+    }
+    
+    var end: Timetable.Time {
+        let value = compactMap { $0.last?.end.value }.max()
+        guard let value else { return .init(hour: 24, minute: 0) }
+        let time = Timetable.Time(value: value)
+        return .init(hour: time.hour + 1, minute: 0)
+    }
+}

--- a/Projects/DesignSystem/Sources/Timetable/TimetableGridView.swift
+++ b/Projects/DesignSystem/Sources/Timetable/TimetableGridView.swift
@@ -1,0 +1,143 @@
+//
+//  TimetableGridView.swift
+//  DesignSystem
+//
+//  Created by 이정원 on 6/17/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import SwiftUI
+
+struct TimetableGridView: View {
+    private let schedules: [[Timetable.Schedule]]
+    
+    init(schedules: [[Timetable.Schedule]]) {
+        self.schedules = schedules
+    }
+    
+    var body: some View {
+        ZStack(alignment: .top) {
+            gridBackgroundView
+            
+            HStack(alignment: .top, spacing: 8) {
+                ForEach(0..<schedules.count, id: \.self) { index in
+                    let stageSchedules = schedules[index]
+                    ZStack(alignment: .top) {
+                        ForEach(0..<stageSchedules.count, id: \.self) { index in
+                            let schedule = stageSchedules[index]
+                            
+                            if schedules.count > 3 {
+                                scheduleView(schedule: schedule)
+                                    .frame(width: 86)
+                            } else {
+                                scheduleView(schedule: schedule)
+                                    .frame(maxWidth: .infinity)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 8)
+        }
+        .padding(.top, 1)
+    }
+}
+
+private extension TimetableGridView {
+    var gridBackgroundView: some View {
+        VStack(spacing: 0) {
+            let end = schedules.end.hour
+            let start = schedules.start.hour
+            let count = (end - start) * 6
+            
+            ForEach(1...count, id: \.self) { index in
+                Spacer()
+                    .frame(height: 15)
+                
+                if index % 6 == 0 { solidLine }
+                else { dashedLine }
+            }
+        }
+        .frame(height: totalHeight)
+    }
+    
+    var solidLine: some View {
+        Color.grey6
+            .frame(height: 1)
+    }
+    
+    var dashedLine: some View {
+        let strokeStyle = StrokeStyle(
+            lineWidth: 1,
+            lineCap: .round,
+            dash: [3, 4]
+        )
+        
+        return Line()
+            .stroke(Color.grey6, style: strokeStyle)
+    }
+    
+    func scheduleView(schedule: Timetable.Schedule) -> some View {
+        VStack {
+            Text(schedule.artistName)
+                .pretendard(style: .body3)
+                .foregroundStyle(Color.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            
+            Spacer()
+            Text(timeString(of: schedule))
+                .pretendard(style: .caption2)
+                .foregroundStyle(Color.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(8)
+        .frame(height: height(of: schedule))
+        .background(Color.point2.opacity(0.4))
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.point2))
+        .padding(.top, offset(of: schedule))
+    }
+}
+
+private extension TimetableGridView {
+    func offset(of schedule: Timetable.Schedule) -> CGFloat {
+        let start = schedules.start.value
+        let scheduleStart = schedule.start.value
+        return CGFloat(scheduleStart - start) * 1.6
+    }
+    
+    func height(of schedule: Timetable.Schedule) -> CGFloat {
+        let end = schedule.end.value
+        let start = schedule.start.value
+        return CGFloat(end - start) * 1.6
+    }
+    
+    func timeString(of schedule: Timetable.Schedule) -> String {
+        let startHour = schedule.start.hour.toString
+        let startMinute = schedule.start.minute.toString
+        let endHour = schedule.end.hour.toString
+        let endMinute = schedule.end.minute.toString
+        return "\(startHour):\(startMinute)-\(endHour):\(endMinute)"
+    }
+    
+    var totalHeight: CGFloat {
+        let end = schedules.end.value
+        let start = schedules.start.value
+        return CGFloat(end - start) * 1.6
+    }
+}
+
+private extension Int {
+    var toString: String {
+        String(format: "%02d", self)
+    }
+}
+
+private struct Line: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX, y: rect.midY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+        return path
+    }
+}

--- a/Projects/DesignSystem/Sources/Timetable/TimetableView.swift
+++ b/Projects/DesignSystem/Sources/Timetable/TimetableView.swift
@@ -1,0 +1,261 @@
+//
+//  TimetableView.swift
+//  DesignSystem
+//
+//  Created by 이정원 on 6/17/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import UIKit
+import SwiftUI
+
+public struct TimetableView: UIViewRepresentable {
+    private let timetable: Timetable
+    
+    public init(timetable: Timetable) {
+        self.timetable = timetable
+    }
+    
+    public func makeUIView(context: Context) -> UIView {
+        let containerView = UIView()
+        configureContainerView(containerView, context)
+        return containerView
+    }
+    
+    public func updateUIView(_ uiView: UIView, context: Context) {
+        uiView.subviews.forEach { $0.removeFromSuperview() }
+        configureContainerView(uiView, context)
+    }
+    
+    public func makeCoordinator() -> TimetableViewCoordinator {
+        TimetableViewCoordinator()
+    }
+}
+
+private extension TimetableView {
+    struct SubViewGroup {
+        let scrollViewGroup: ScrollViewGroup
+        let contentViewGroup: ContentViewGroup
+        let borderGroup: BorderGroup
+    }
+    
+    struct ScrollViewGroup {
+        let rowHeader: UIScrollView
+        let columnHeader: UIScrollView
+        let grid: UIScrollView
+    }
+    
+    struct ContentViewGroup {
+        let rowHeader: UIView
+        let columnHeader: UIView
+        let grid: UIView
+    }
+    
+    struct BorderGroup {
+        let rowBorder: UIView
+        let columnBorder: UIView
+    }
+}
+
+private extension TimetableView {
+    func configureContainerView(_ containerView: UIView, _ context: Context) {
+        let subViewGroup = makeSubViewGroup()
+        let scrollViewGroup = subViewGroup.scrollViewGroup
+        let contentViewGroup = subViewGroup.contentViewGroup
+        let borderGroup = subViewGroup.borderGroup
+        
+        configureDelegates(context, scrollViewGroup)
+        addSubViews(containerView, subViewGroup)
+        configureScrollViewLayouts(containerView, scrollViewGroup)
+        configureContentViewLayouts(scrollViewGroup, contentViewGroup)
+        configureBorderLayouts(scrollViewGroup, borderGroup)
+    }
+
+    
+    func makeSubViewGroup() -> SubViewGroup {
+        return SubViewGroup(
+            scrollViewGroup: makeScrollViewGroup(),
+            contentViewGroup: makeContentViewGroup(),
+            borderGroup: makeBorderGroup()
+        )
+    }
+    
+    func makeScrollViewGroup() -> ScrollViewGroup {
+        return ScrollViewGroup(
+            rowHeader: makeScrollView(),
+            columnHeader: makeScrollView(),
+            grid: makeScrollView()
+        )
+    }
+    
+    func makeScrollView() -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.bounces = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.isDirectionalLockEnabled = true
+        return scrollView
+    }
+    
+    func makeContentViewGroup() -> ContentViewGroup {
+        let schedules = timetable.schedules
+        let start = schedules.start.hour
+        let end = schedules.end.hour
+        
+        let timeHeaderView = TimeHeaderView(start: start, end: end)
+        let stageHeaderView = StageHeaderView(stages: timetable.stages)
+        let timetableGridView = TimetableGridView(schedules: schedules)
+        
+        return ContentViewGroup(
+            rowHeader: makeContentView(timeHeaderView),
+            columnHeader: makeContentView(stageHeaderView),
+            grid: makeContentView(timetableGridView)
+        )
+    }
+    
+    func makeContentView<Content: View>(_ content: Content) -> UIView {
+        let controller = UIHostingController(rootView: content)
+        controller.view.translatesAutoresizingMaskIntoConstraints = false
+        controller.view.backgroundColor = .clear
+        return controller.view
+    }
+    
+    func makeBorderGroup() -> BorderGroup {
+        return BorderGroup(
+            rowBorder: makeBorderView(),
+            columnBorder: makeBorderView()
+        )
+    }
+    
+    func makeBorderView() -> UIView {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = UIColor(Color.grey6)
+        return view
+    }
+    
+    func configureDelegates(_ context: Context, _ group: ScrollViewGroup) {
+        let coordinator = context.coordinator
+        group.rowHeader.delegate = coordinator
+        group.columnHeader.delegate = coordinator
+        group.grid.delegate = coordinator
+        coordinator.rowHeaderScrollView = group.rowHeader
+        coordinator.columnHeaderScrollView = group.columnHeader
+        coordinator.gridScrollView = group.grid
+    }
+    
+    func addSubViews(
+        _ containerView: UIView,
+        _ subViewGroup: SubViewGroup
+    ) {
+        let scrollViewGroup = subViewGroup.scrollViewGroup
+        let contentViewGroup = subViewGroup.contentViewGroup
+        let borderGroup = subViewGroup.borderGroup
+        
+        scrollViewGroup.rowHeader.addSubview(contentViewGroup.rowHeader)
+        scrollViewGroup.columnHeader.addSubview(contentViewGroup.columnHeader)
+        scrollViewGroup.grid.addSubview(contentViewGroup.grid)
+        
+        containerView.addSubview(scrollViewGroup.rowHeader)
+        containerView.addSubview(scrollViewGroup.columnHeader)
+        containerView.addSubview(scrollViewGroup.grid)
+        containerView.addSubview(borderGroup.rowBorder)
+        containerView.addSubview(borderGroup.columnBorder)
+    }
+    
+    func configureScrollViewLayouts(
+        _ containerView: UIView,
+        _ group: ScrollViewGroup
+    ) {
+        let rowHeader = group.rowHeader
+        let columnHeader = group.columnHeader
+        let grid = group.grid
+        
+        NSLayoutConstraint.activate([
+            rowHeader.topAnchor.constraint(equalTo: columnHeader.bottomAnchor, constant: -1),
+            rowHeader.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            rowHeader.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            rowHeader.widthAnchor.constraint(equalToConstant: 50),
+            
+            columnHeader.topAnchor.constraint(equalTo: containerView.topAnchor),
+            columnHeader.leadingAnchor.constraint(equalTo: rowHeader.trailingAnchor),
+            columnHeader.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            columnHeader.heightAnchor.constraint(equalToConstant: 34),
+            
+            grid.topAnchor.constraint(equalTo: columnHeader.bottomAnchor),
+            grid.leadingAnchor.constraint(equalTo: rowHeader.trailingAnchor),
+            grid.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            grid.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+        ])
+    }
+    
+    func configureContentViewLayouts(
+        _ scrollViewGroup: ScrollViewGroup,
+        _ contentViewGroup: ContentViewGroup
+    ) {
+        let rowHeader = scrollViewGroup.rowHeader
+        let columnHeader = scrollViewGroup.columnHeader
+        let grid = scrollViewGroup.grid
+        
+        let rowHeaderContent = contentViewGroup.rowHeader
+        let columnHeaderContent = contentViewGroup.columnHeader
+        let gridContent = contentViewGroup.grid
+        
+        NSLayoutConstraint.activate([
+            gridContent.topAnchor.constraint(equalTo: grid.contentLayoutGuide.topAnchor),
+            gridContent.leadingAnchor.constraint(equalTo: grid.contentLayoutGuide.leadingAnchor),
+            gridContent.trailingAnchor.constraint(equalTo: grid.contentLayoutGuide.trailingAnchor),
+            gridContent.bottomAnchor.constraint(equalTo: grid.contentLayoutGuide.bottomAnchor),
+            
+            rowHeaderContent.topAnchor.constraint(equalTo: rowHeader.contentLayoutGuide.topAnchor),
+            rowHeaderContent.leadingAnchor.constraint(equalTo: rowHeader.contentLayoutGuide.leadingAnchor),
+            rowHeaderContent.trailingAnchor.constraint(equalTo: rowHeader.contentLayoutGuide.trailingAnchor),
+            rowHeaderContent.bottomAnchor.constraint(equalTo: rowHeader.contentLayoutGuide.bottomAnchor),
+            rowHeaderContent.widthAnchor.constraint(equalTo: rowHeader.frameLayoutGuide.widthAnchor),
+            
+            columnHeaderContent.topAnchor.constraint(equalTo: columnHeader.contentLayoutGuide.topAnchor),
+            columnHeaderContent.leadingAnchor.constraint(equalTo: columnHeader.contentLayoutGuide.leadingAnchor),
+            columnHeaderContent.trailingAnchor.constraint(equalTo: columnHeader.contentLayoutGuide.trailingAnchor),
+            columnHeaderContent.bottomAnchor.constraint(equalTo: columnHeader.contentLayoutGuide.bottomAnchor),
+            columnHeaderContent.heightAnchor.constraint(equalTo: columnHeader.frameLayoutGuide.heightAnchor),
+        ])
+        
+        if timetable.schedules.count > 3 {
+            let count = CGFloat(timetable.schedules.count)
+            let width = 86.0 * count + 8.0 * (count + 1)
+            
+            NSLayoutConstraint.activate([
+                gridContent.widthAnchor.constraint(equalToConstant: width),
+                columnHeaderContent.widthAnchor.constraint(equalToConstant: width),
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                gridContent.widthAnchor.constraint(equalTo: grid.frameLayoutGuide.widthAnchor),
+                columnHeaderContent.widthAnchor.constraint(equalTo: columnHeader.frameLayoutGuide.widthAnchor),
+            ])
+        }
+    }
+    
+    func configureBorderLayouts(
+        _ scrollViewGroup: ScrollViewGroup,
+        _ borderGroup: BorderGroup
+    ) {
+        let rowBorder = borderGroup.rowBorder
+        let columnBorder = borderGroup.columnBorder
+        let rowHeader = scrollViewGroup.rowHeader
+        let columnHeader = scrollViewGroup.columnHeader
+        
+        NSLayoutConstraint.activate([
+            rowBorder.topAnchor.constraint(equalTo: columnHeader.topAnchor),
+            rowBorder.bottomAnchor.constraint(equalTo: rowHeader.bottomAnchor),
+            rowBorder.trailingAnchor.constraint(equalTo: columnHeader.leadingAnchor),
+            rowBorder.widthAnchor.constraint(equalToConstant: 1),
+            
+            columnBorder.leadingAnchor.constraint(equalTo: rowHeader.trailingAnchor),
+            columnBorder.trailingAnchor.constraint(equalTo: columnHeader.trailingAnchor),
+            columnBorder.bottomAnchor.constraint(equalTo: columnHeader.bottomAnchor),
+            columnBorder.heightAnchor.constraint(equalToConstant: 1),
+        ])
+    }
+}

--- a/Projects/DesignSystem/Sources/Timetable/TimetableViewCoordinator.swift
+++ b/Projects/DesignSystem/Sources/Timetable/TimetableViewCoordinator.swift
@@ -1,0 +1,39 @@
+//
+//  TimetableViewCoordinator.swift
+//  DesignSystem
+//
+//  Created by 이정원 on 6/19/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import UIKit
+
+public final class TimetableViewCoordinator: NSObject, UIScrollViewDelegate {
+    var rowHeaderScrollView: UIScrollView?
+    var columnHeaderScrollView: UIScrollView?
+    var gridScrollView: UIScrollView?
+    private var isScrollHandling = false
+  
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if isScrollHandling { return }
+        isScrollHandling = true
+        defer { isScrollHandling = false }
+
+        let offset = scrollView.contentOffset
+        let rowHeaderOffset = CGPoint(x: 0, y: offset.y)
+        let columnHeaderOffset = CGPoint(x: offset.x, y: 0)
+        let currentGridX = gridScrollView?.contentOffset.x ?? 0.0
+        let currentGridY = gridScrollView?.contentOffset.y ?? 0.0
+
+        if scrollView == gridScrollView {
+            rowHeaderScrollView?.setContentOffset(rowHeaderOffset, animated: false)
+            columnHeaderScrollView?.setContentOffset(columnHeaderOffset, animated: false)
+        } else if scrollView == rowHeaderScrollView {
+            let offset = CGPoint(x: currentGridX, y: offset.y)
+            gridScrollView?.setContentOffset(offset, animated: false)
+        } else if scrollView == columnHeaderScrollView {
+            let offset = CGPoint(x: offset.x, y: currentGridY)
+            gridScrollView?.setContentOffset(offset, animated: false)
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호를 명시하세요 (예: Closes #123, Resolves #45) -->
- #11 

---

## ✨ 작업 내용
<!-- 어떤 기능/버그/리팩토링 작업을 했는지 간단하게 작성해주세요 -->
- Timetable UI를 구현하였습니다. 현재는 모든 이벤트가 색칠되어 있는 상태고 터치할 수 있는 버튼이 아니지만,
추후에 더 자세한 디자인 시안이 나오면 수정하겠습니다.
- Column이 3개일 때까지는 Grid 화면을 균등하게 분할하여 width를 설정하고
4개 이상일 때에는 86px의 고정된 width로 설정하여 좌우 스크롤이 가능하게 하였습니다.
- SwiftUI로만 구현하기에는 제한 사항이 있어 UIViewRepresentable 프로토콜을 채택하고, UIKit으로 구현하였습니다.
시간 헤더, 스테이지 헤더, 타임테이블 그리드 총 3개의 스크롤뷰를 하나의 코디네이터가 담당하여
스크롤이 발생했을 때 각 스크롤 뷰가 어떻게 움직여야 하는 지를 설정해주었습니다.

---

## 📸 Showcase
<!-- UI 변경이 있는 경우, 캡처 이미지나 GIF를 첨부해주세요 -->
| DesignSystem 홈 화면 |
|--------|
|<img src="https://github.com/user-attachments/assets/bfd96936-a007-433b-9059-8cf6fe06c175"  width="300" />|

| Column 1개 |  Column 2개 | 
|--------|--------|
|<img src="https://github.com/user-attachments/assets/716806e6-9986-457e-a6bf-39860b7f34a4"  width="300" />|<img src="https://github.com/user-attachments/assets/524f121c-b02d-4959-8341-6569a7b3ee05"  width="300" />|

| Column 3개 |  Column 4개 | 
|--------|--------|
|<img src="https://github.com/user-attachments/assets/e7ef72a9-3f4d-4d99-8ff7-007f8ec07cf9"  width="300" />|<img src="https://github.com/user-attachments/assets/ceb089c2-e66c-46d5-a67c-a585dde6fd90"  width="300" />|

---

## 📝 참고 사항
<!-- 리뷰어가 이해를 돕기 위한 추가 설명이나 논의 사항이 있다면 여기에 작성하세요 -->
- DesignSystemDemo Scheme을 선택하여 빌드하면 메뉴 리스트가 나오고 Timetable 항목을 선택해서 UI를 확인하실 수 있습니다.
상단의 Stage 개수 변경 텍스트를 클릭하면 Column이 1, 2, 3, 4 순으로 돌아가며 변경됩니다.
- #10 PR이 머지되면 타겟 브랜치 변경하겠습니다.
