### PR TITLE
[Feat] 아티스트 리스트 화면 UI 구현

### DIFF
--- a/Projects/Features/Home/Sources/ArtistList/ArtistListFeature.swift
+++ b/Projects/Features/Home/Sources/ArtistList/ArtistListFeature.swift
@@ -7,6 +7,7 @@
 //
 
 import ComposableArchitecture
+import Domain
 
 @Reducer
 public struct ArtistListFeature {
@@ -14,8 +15,36 @@ public struct ArtistListFeature {
     
     @ObservableState
     public struct State {
-        var totalDays: Int = 3
-        var selectedDay: Int = 1
+        var totalDays: Int = 6
+        var selectedIndex: Int = 0
+        
+        var artists: [[Artist]] = [
+            .init(
+                repeating: .init(name: "아티스트명아티스트명아티스트명아티스트명", imageURLString: ""),
+                count: 11
+            ),
+            .init(
+                repeating: .init(name: "아티스트명", imageURLString: ""),
+                count: 9
+            ),
+            .init(
+                repeating: .init(name: "아티스트명", imageURLString: ""),
+                count: 7
+            ),
+            .init(
+                repeating: .init(name: "아티스트명아티스트명아티스트명아티스트명", imageURLString: ""),
+                count: 5
+            ),
+            .init(
+                repeating: .init(name: "아티스트명", imageURLString: ""),
+                count: 3
+            ),
+            .init(
+                repeating: .init(name: "아티스트명", imageURLString: ""),
+                count: 1
+            )
+        ]
+        
         public init() {}
     }
     
@@ -30,8 +59,8 @@ public struct ArtistListFeature {
             switch action {
             case .backButtonTapped:
                 return .run { _ in await dismiss() }
-            case .dayButtonTapped(let day):
-                state.selectedDay = day
+            case .dayButtonTapped(let index):
+                state.selectedIndex = index
                 return .none
             }
         }

--- a/Projects/Features/Home/Sources/ArtistList/ArtistListFeature.swift
+++ b/Projects/Features/Home/Sources/ArtistList/ArtistListFeature.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 Darayo. All rights reserved.
 //
 
+import Foundation
 import ComposableArchitecture
 import Domain
 
@@ -15,53 +16,53 @@ public struct ArtistListFeature {
     
     @ObservableState
     public struct State {
-        var totalDays: Int = 6
-        var selectedIndex: Int = 0
+        var tabIndex: Int = 0
+        var indexToScroll: (Int, Date)?
+        var artists: [[Artist]]
         
-        var artists: [[Artist]] = [
-            .init(
-                repeating: .init(name: "아티스트명아티스트명아티스트명아티스트명", imageURLString: ""),
-                count: 11
-            ),
-            .init(
-                repeating: .init(name: "아티스트명", imageURLString: ""),
-                count: 9
-            ),
-            .init(
-                repeating: .init(name: "아티스트명", imageURLString: ""),
-                count: 7
-            ),
-            .init(
-                repeating: .init(name: "아티스트명아티스트명아티스트명아티스트명", imageURLString: ""),
-                count: 5
-            ),
-            .init(
-                repeating: .init(name: "아티스트명", imageURLString: ""),
-                count: 3
-            ),
-            .init(
-                repeating: .init(name: "아티스트명", imageURLString: ""),
-                count: 1
+        public init() {
+            let count = (1...4).randomElement()!
+            let artist = Artist(
+                name: (0..<count).map { _ in "아티스트명" }.joined(),
+                imageURLString: ""
             )
-        ]
+            
+            self.artists = .init(
+                repeating: .init(
+                    repeating: artist,
+                    count: (1...12).randomElement()!
+                ),
+                count: (1...8).randomElement()!
+            )
+        }
         
-        public init() {}
+        var totalDays: Int {
+            artists.count
+        }
     }
     
-    public enum Action {
+    public enum Action: BindableAction {
         case backButtonTapped
         case dayButtonTapped(Int)
+        case indexChanged(Int)
+        case binding(BindingAction<State>)
     }
     
     public init() {}
     public var body: some ReducerOf<Self> {
+        BindingReducer()
+        
         Reduce { state, action in
             switch action {
             case .backButtonTapped:
                 return .run { _ in await dismiss() }
             case .dayButtonTapped(let index):
-                state.selectedIndex = index
+                state.indexToScroll = (index, .now)
                 return .none
+            case .indexChanged(let index):
+                state.tabIndex = index
+                return .none
+            case .binding: return .none
             }
         }
     }

--- a/Projects/Features/Home/Sources/ArtistList/ArtistListFeature.swift
+++ b/Projects/Features/Home/Sources/ArtistList/ArtistListFeature.swift
@@ -21,19 +21,15 @@ public struct ArtistListFeature {
         var artists: [[Artist]]
         
         public init() {
-            let count = (1...4).randomElement()!
-            let artist = Artist(
-                name: (0..<count).map { _ in "아티스트명" }.joined(),
-                imageURLString: ""
-            )
-            
-            self.artists = .init(
-                repeating: .init(
-                    repeating: artist,
-                    count: (1...12).randomElement()!
-                ),
-                count: (1...8).randomElement()!
-            )
+            let count = (1...8).randomElement()!
+            self.artists = (0..<count).map { _ in
+                let count = (1...12).randomElement()!
+                return (0..<count).map { _ in
+                    let count = (1...5).randomElement()!
+                    let name = (0..<count).map { _ in "아티스트" }.joined()
+                    return Artist(name: name, imageURLString: "")
+                }
+            }
         }
         
         var totalDays: Int {

--- a/Projects/Features/Home/Sources/ArtistList/ArtistListFeature.swift
+++ b/Projects/Features/Home/Sources/ArtistList/ArtistListFeature.swift
@@ -25,9 +25,7 @@ public struct ArtistListFeature {
             self.artists = (0..<count).map { _ in
                 let count = (1...12).randomElement()!
                 return (0..<count).map { _ in
-                    let count = (1...5).randomElement()!
-                    let name = (0..<count).map { _ in "아티스트" }.joined()
-                    return Artist(name: name, imageURLString: "")
+                    return Artist(name: "아티스트명", imageURLString: "")
                 }
             }
         }

--- a/Projects/Features/Home/Sources/ArtistList/ArtistListFeature.swift
+++ b/Projects/Features/Home/Sources/ArtistList/ArtistListFeature.swift
@@ -1,0 +1,39 @@
+//
+//  ArtistListFeature.swift
+//  Home
+//
+//  Created by 이정원 on 7/2/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import ComposableArchitecture
+
+@Reducer
+public struct ArtistListFeature {
+    @Dependency(\.dismiss) private var dismiss
+    
+    @ObservableState
+    public struct State {
+        var totalDays: Int = 3
+        var selectedDay: Int = 1
+        public init() {}
+    }
+    
+    public enum Action {
+        case backButtonTapped
+        case dayButtonTapped(Int)
+    }
+    
+    public init() {}
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .backButtonTapped:
+                return .run { _ in await dismiss() }
+            case .dayButtonTapped(let day):
+                state.selectedDay = day
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Features/Home/Sources/ArtistList/ArtistListView.swift
+++ b/Projects/Features/Home/Sources/ArtistList/ArtistListView.swift
@@ -1,0 +1,58 @@
+//
+//  ArtistListView.swift
+//  Home
+//
+//  Created by 이정원 on 7/2/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import DesignSystem
+
+public struct ArtistListView: View {
+    private let store: StoreOf<ArtistListFeature>
+    
+    public init(store: StoreOf<ArtistListFeature>) {
+        self.store = store
+    }
+    
+    public var body: some View {
+        VStack(spacing: 0) {
+            navigationBar
+            dayListView
+            Spacer()
+        }
+        .navigationBarBackButtonHidden()
+        .background(Color.background1)
+    }
+}
+
+private extension ArtistListView {
+    var navigationBar: some View {
+        ZStack(alignment: .leading) {
+            Text("아티스트 리스트")
+                .pretendard(style: .title2)
+                .frame(maxWidth: .infinity)
+                .frame(height: 56)
+            
+            Button {
+                store.send(.backButtonTapped)
+            } label: {
+                Image.iconArrowLeft
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                    .padding(16)
+            }
+        }
+    }
+    
+    var dayListView: some View {
+        DayListView(
+            totalDays: store.totalDays,
+            selectedDay: store.selectedDay
+        ) { day in
+            store.send(.dayButtonTapped(day))
+        }
+    }
+}

--- a/Projects/Features/Home/Sources/ArtistList/ArtistListView.swift
+++ b/Projects/Features/Home/Sources/ArtistList/ArtistListView.swift
@@ -21,7 +21,7 @@ public struct ArtistListView: View {
         VStack(spacing: 0) {
             navigationBar
             dayListView
-            Spacer()
+            artistGridListView
         }
         .navigationBarBackButtonHidden()
         .background(Color.background1)
@@ -50,9 +50,16 @@ private extension ArtistListView {
     var dayListView: some View {
         DayListView(
             totalDays: store.totalDays,
-            selectedDay: store.selectedDay
+            selectedIndex: store.selectedIndex
         ) { day in
             store.send(.dayButtonTapped(day))
         }
+    }
+    
+    var artistGridListView: some View {
+        ArtistGridListView(
+            artists: store.artists,
+            selectedIndex: store.selectedIndex
+        )
     }
 }

--- a/Projects/Features/Home/Sources/ArtistList/ArtistListView.swift
+++ b/Projects/Features/Home/Sources/ArtistList/ArtistListView.swift
@@ -11,7 +11,7 @@ import ComposableArchitecture
 import DesignSystem
 
 public struct ArtistListView: View {
-    private let store: StoreOf<ArtistListFeature>
+    @Bindable private var store: StoreOf<ArtistListFeature>
     
     public init(store: StoreOf<ArtistListFeature>) {
         self.store = store
@@ -50,16 +50,18 @@ private extension ArtistListView {
     var dayListView: some View {
         DayListView(
             totalDays: store.totalDays,
-            selectedIndex: store.selectedIndex
-        ) { day in
-            store.send(.dayButtonTapped(day))
+            selectedIndex: store.tabIndex
+        ) { index in
+            store.send(.dayButtonTapped(index))
         }
     }
     
     var artistGridListView: some View {
         ArtistGridListView(
             artists: store.artists,
-            selectedIndex: store.selectedIndex
-        )
+            indexToScroll: store.indexToScroll
+        ) { index in
+            store.send(.indexChanged(index))
+        }
     }
 }

--- a/Projects/Features/Home/Sources/ArtistList/Components/ArtistGridListView.swift
+++ b/Projects/Features/Home/Sources/ArtistList/Components/ArtistGridListView.swift
@@ -12,43 +12,41 @@ import Domain
 
 struct ArtistGridListView: View {
     private let artists: [[Artist]]
-    private let selectedIndex: Int
+    private let indexToScroll: (Int, Date)?
+    private let onIndexChange: (Int) -> Void
+    
+    @State private var bottomPadding: CGFloat = 0
     
     init(
         artists: [[Artist]],
-        selectedIndex: Int
+        indexToScroll: (Int, Date)?,
+        onIndexChange: @escaping (Int) -> Void
     ) {
         self.artists = artists
-        self.selectedIndex = selectedIndex
+        self.indexToScroll = indexToScroll
+        self.onIndexChange = onIndexChange
     }
-    
-    private let columns = [
-        GridItem(.flexible(), spacing: 20),
-        GridItem(.flexible(), spacing: 20),
-        GridItem(.flexible(), spacing: 20)
-    ]
+
+    private let columns: [GridItem] = .init(
+        repeating: .init(.flexible(), spacing: 20),
+        count: 3
+    )
     
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(0..<artists.count, id: \.self) { index in
-                        VStack(spacing: 0) {
-                            Text("DAY\(index + 1)")
-                                .pretendard(style: .title1)
-                                .foregroundStyle(Color.point1)
-                                .frame(maxWidth: .infinity)
-                                .id(index)
-                            
-                            artistGridView(artists[index])
-                        }
-                    }
+        GeometryReader { geometryProxy in
+            ScrollViewReader { scrollProxy in
+                ScrollView {
+                    artistGridListView()
                 }
-                .padding(.horizontal, 16)
-            }
-            .onChange(of: selectedIndex) { _, index in
-                withAnimation {
-                    proxy.scrollTo(index, anchor: .top)
+                .onPreferenceChange(AnchorsKey.self) { anchors in
+                    updateIndex(geometryProxy, anchors)
+                    updateBottomPadding(geometryProxy, anchors)
+                }
+                .onChange(of: indexToScroll?.1) { _, _ in
+                    guard let index = indexToScroll?.0 else { return }
+                    withAnimation {
+                        scrollProxy.scrollTo(index, anchor: .top)
+                    }
                 }
             }
         }
@@ -56,6 +54,30 @@ struct ArtistGridListView: View {
 }
 
 private extension ArtistGridListView {
+    func artistGridListView() -> some View {
+        VStack(spacing: 0) {
+            ForEach(0..<artists.count, id: \.self) { index in
+                VStack(spacing: 0) {
+                    textHeaderView(index)
+                    artistGridView(artists[index])
+                }
+                .anchorPreference(key: AnchorsKey.self, value: .bounds) { anchor in
+                    [index: anchor]
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, bottomPadding)
+    }
+    
+    func textHeaderView(_ index: Int) -> some View {
+        Text("DAY\(index + 1)")
+            .pretendard(style: .title1)
+            .foregroundStyle(Color.point1)
+            .frame(maxWidth: .infinity)
+            .id(index)
+    }
+    
     func artistGridView(_ artists: [Artist]) -> some View {
         LazyVGrid(columns: columns, spacing: 16) {
             ForEach(0..<artists.count, id: \.self) { index in
@@ -78,5 +100,36 @@ private extension ArtistGridListView {
                 .frame(maxWidth: .infinity)
                 .multilineTextAlignment(.center)
         }
+    }
+}
+
+private extension ArtistGridListView {
+    func updateIndex(_ proxy: GeometryProxy, _ anchors: [Int: Anchor<CGRect>]) {
+        let index = anchors
+            .filter{ proxy[$0.value].maxY > 0 }
+            .sorted { proxy[$0.value].maxY < proxy[$1.value].maxY }
+            .first?.key
+        
+        guard let index else { return }
+        onIndexChange(index)
+    }
+    
+    func updateBottomPadding(_ proxy: GeometryProxy, _ anchors: [Int: Anchor<CGRect>]) {
+        guard let lastAnchor = anchors[artists.count - 1] else { return }
+        let lastItemHeight = proxy[lastAnchor].height
+        let scrollViewHeight = proxy.size.height
+        let extraPadding = max(0, scrollViewHeight - lastItemHeight)
+        bottomPadding = extraPadding
+    }
+}
+
+private struct AnchorsKey: PreferenceKey {
+    static var defaultValue: [Int: Anchor<CGRect>] = [:]
+    
+    static func reduce(
+        value: inout [Int: Anchor<CGRect>],
+        nextValue: () -> [Int: Anchor<CGRect>]
+    ) {
+        value.merge(nextValue()) { $1 }
     }
 }

--- a/Projects/Features/Home/Sources/ArtistList/Components/ArtistGridListView.swift
+++ b/Projects/Features/Home/Sources/ArtistList/Components/ArtistGridListView.swift
@@ -1,0 +1,82 @@
+//
+//  ArtistGridListView.swift
+//  Home
+//
+//  Created by 이정원 on 7/3/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import SwiftUI
+import DesignSystem
+import Domain
+
+struct ArtistGridListView: View {
+    private let artists: [[Artist]]
+    private let selectedIndex: Int
+    
+    init(
+        artists: [[Artist]],
+        selectedIndex: Int
+    ) {
+        self.artists = artists
+        self.selectedIndex = selectedIndex
+    }
+    
+    private let columns = [
+        GridItem(.flexible(), spacing: 20),
+        GridItem(.flexible(), spacing: 20),
+        GridItem(.flexible(), spacing: 20)
+    ]
+    
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(0..<artists.count, id: \.self) { index in
+                        VStack(spacing: 0) {
+                            Text("DAY\(index + 1)")
+                                .pretendard(style: .title1)
+                                .foregroundStyle(Color.point1)
+                                .frame(maxWidth: .infinity)
+                                .id(index)
+                            
+                            artistGridView(artists[index])
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+            .onChange(of: selectedIndex) { _, index in
+                withAnimation {
+                    proxy.scrollTo(index, anchor: .top)
+                }
+            }
+        }
+    }
+}
+
+private extension ArtistGridListView {
+    func artistGridView(_ artists: [Artist]) -> some View {
+        LazyVGrid(columns: columns, spacing: 16) {
+            ForEach(0..<artists.count, id: \.self) { index in
+                artistView(artists[index])
+            }
+        }
+        .padding(.vertical, 16)
+    }
+    
+    func artistView(_ artist: Artist) -> some View {
+        VStack(spacing: 6) {
+            Image.iconArtistPlaceholder
+                .resizable()
+                .frame(maxWidth: .infinity)
+                .aspectRatio(1.0, contentMode: .fit)
+            
+            Text(artist.name)
+                .pretendard(style: .body3)
+                .foregroundStyle(Color.white)
+                .frame(maxWidth: .infinity)
+                .multilineTextAlignment(.center)
+        }
+    }
+}

--- a/Projects/Features/Home/Sources/ArtistList/Components/ArtistGridListView.swift
+++ b/Projects/Features/Home/Sources/ArtistList/Components/ArtistGridListView.swift
@@ -28,7 +28,7 @@ struct ArtistGridListView: View {
     }
 
     private let columns: [GridItem] = .init(
-        repeating: .init(.flexible(), spacing: 20),
+        repeating: .init(.flexible(), spacing: 20, alignment: .top),
         count: 3
     )
     

--- a/Projects/Features/Home/Sources/ArtistList/Components/ArtistGridListView.swift
+++ b/Projects/Features/Home/Sources/ArtistList/Components/ArtistGridListView.swift
@@ -50,6 +50,8 @@ struct ArtistGridListView: View {
                 }
             }
         }
+        .overlay(alignment: .bottom) { gradient }
+        .ignoresSafeArea()
     }
 }
 
@@ -101,6 +103,19 @@ private extension ArtistGridListView {
                 .multilineTextAlignment(.center)
         }
     }
+    
+    var gradient: some View {
+        LinearGradient(
+            stops: [
+                Gradient.Stop(color: Color.background1.opacity(0), location: 0.00),
+                Gradient.Stop(color: Color.background1, location: 1.00)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+        .frame(height: 184)
+        .allowsHitTesting(false)
+    }
 }
 
 private extension ArtistGridListView {
@@ -118,7 +133,7 @@ private extension ArtistGridListView {
         guard let lastAnchor = anchors[artists.count - 1] else { return }
         let lastItemHeight = proxy[lastAnchor].height
         let scrollViewHeight = proxy.size.height
-        let extraPadding = max(0, scrollViewHeight - lastItemHeight)
+        let extraPadding = max(184, scrollViewHeight - lastItemHeight)
         bottomPadding = extraPadding
     }
 }

--- a/Projects/Features/Home/Sources/ArtistList/Components/DayListView.swift
+++ b/Projects/Features/Home/Sources/ArtistList/Components/DayListView.swift
@@ -1,0 +1,110 @@
+//
+//  DayListView.swift
+//  Home
+//
+//  Created by 이정원 on 7/2/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import SwiftUI
+import DesignSystem
+
+struct DayListView: View {
+    private let totalDays: Int
+    private let selectedDay: Int
+    private let action: (Int) -> Void
+    
+    @State private var width: CGFloat = .infinity
+
+    init(
+        totalDays: Int,
+        selectedDay: Int,
+        action: @escaping (Int) -> Void
+    ) {
+        self.totalDays = totalDays
+        self.selectedDay = selectedDay
+        self.action = action
+    }
+    
+    var body: some View {
+        GeometryReader { proxy in
+            let canScroll = canScroll(proxy.size.width)
+            
+            if canScroll {
+                ScrollViewReader { proxy in
+                    ScrollView(.horizontal) {
+                        dayListView(canScroll: canScroll)
+                    }
+                    .scrollIndicators(.hidden)
+                    .onChange(of: selectedDay) { _, day in
+                        withAnimation {
+                            proxy.scrollTo(day, anchor: .center)
+                        }
+                    }
+                }
+            } else {
+                dayListView(canScroll: canScroll)
+            }
+        }
+    }
+}
+
+private extension DayListView {
+    func canScroll(_ width: CGFloat) -> Bool {
+        if self.width == .infinity { return true }
+        return Int(self.width) > Int(width)
+    }
+}
+
+private extension DayListView {
+    func dayListView(canScroll: Bool) -> some View {
+        HStack(spacing: canScroll ? 12 : 0) {
+            ForEach(1...totalDays, id: \.self) { day in
+                Button {
+                    action(day)
+                } label: {
+                    switch canScroll {
+                    case true:
+                        textView(day)
+                    case false:
+                        textView(day)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .id(day)
+            }
+        }
+        .frame(height: 20.8)
+        .padding(.vertical, 16)
+        .background(backgroundView)
+    }
+    
+    func textView(_ day: Int) -> some View {
+        let isSelected = day == selectedDay
+        
+        return Text("DAY\(day)")
+            .pretendard(style: .title3)
+            .foregroundStyle(isSelected ? Color.point1 : Color.grey4)
+            .padding(.horizontal, 16)
+    }
+    
+    var backgroundView: some View {
+        GeometryReader { proxy in
+            Color.clear.preference(
+                key: ContentWidthkey.self,
+                value: proxy.size.width
+            )
+        }
+        .onPreferenceChange(ContentWidthkey.self) { width in
+            self.width = width
+        }
+    }
+}
+
+private struct ContentWidthkey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}

--- a/Projects/Features/Home/Sources/ArtistList/Components/DayListView.swift
+++ b/Projects/Features/Home/Sources/ArtistList/Components/DayListView.swift
@@ -11,18 +11,19 @@ import DesignSystem
 
 struct DayListView: View {
     private let totalDays: Int
-    private let selectedDay: Int
+    private let selectedIndex: Int
     private let action: (Int) -> Void
     
     @State private var width: CGFloat = .infinity
+    private let height: CGFloat = 20.8
 
     init(
         totalDays: Int,
-        selectedDay: Int,
+        selectedIndex: Int,
         action: @escaping (Int) -> Void
     ) {
         self.totalDays = totalDays
-        self.selectedDay = selectedDay
+        self.selectedIndex = selectedIndex
         self.action = action
     }
     
@@ -36,9 +37,9 @@ struct DayListView: View {
                         dayListView(canScroll: canScroll)
                     }
                     .scrollIndicators(.hidden)
-                    .onChange(of: selectedDay) { _, day in
+                    .onChange(of: selectedIndex) { _, index in
                         withAnimation {
-                            proxy.scrollTo(day, anchor: .center)
+                            proxy.scrollTo(index, anchor: .center)
                         }
                     }
                 }
@@ -46,6 +47,7 @@ struct DayListView: View {
                 dayListView(canScroll: canScroll)
             }
         }
+        .frame(height: height + 32)
     }
 }
 
@@ -59,30 +61,30 @@ private extension DayListView {
 private extension DayListView {
     func dayListView(canScroll: Bool) -> some View {
         HStack(spacing: canScroll ? 12 : 0) {
-            ForEach(1...totalDays, id: \.self) { day in
+            ForEach(0..<totalDays, id: \.self) { index in
                 Button {
-                    action(day)
+                    action(index)
                 } label: {
                     switch canScroll {
                     case true:
-                        textView(day)
+                        textView(index)
                     case false:
-                        textView(day)
+                        textView(index)
                             .frame(maxWidth: .infinity)
                     }
                 }
-                .id(day)
+                .id(index)
             }
         }
-        .frame(height: 20.8)
+        .frame(height: height)
         .padding(.vertical, 16)
         .background(backgroundView)
     }
     
-    func textView(_ day: Int) -> some View {
-        let isSelected = day == selectedDay
+    func textView(_ index: Int) -> some View {
+        let isSelected = index == selectedIndex
         
-        return Text("DAY\(day)")
+        return Text("DAY\(index + 1)")
             .pretendard(style: .title3)
             .foregroundStyle(isSelected ? Color.point1 : Color.grey4)
             .padding(.horizontal, 16)

--- a/Projects/Features/Home/Sources/Festival/FestivalFeature.swift
+++ b/Projects/Features/Home/Sources/Festival/FestivalFeature.swift
@@ -29,6 +29,7 @@ public struct FestivalFeature {
         case backButtonTapped
         case notificationButtonTapped
         case heartButtonTapped
+        case seeAllButtonTapped
         case binding(BindingAction<State>)
     }
     
@@ -46,6 +47,7 @@ public struct FestivalFeature {
             case .heartButtonTapped:
                 state.isFavorite.toggle()
                 return .none
+            case .seeAllButtonTapped: return .none
             case .binding: return .none
             }
         }

--- a/Projects/Features/Home/Sources/Festival/FestivalView.swift
+++ b/Projects/Features/Home/Sources/Festival/FestivalView.swift
@@ -141,7 +141,7 @@ private extension FestivalView {
                 count: 10
             )
         ) {
-            
+            store.send(.seeAllButtonTapped)
         }
     }
     

--- a/Projects/Features/Root/Sources/Main/MainFeature.swift
+++ b/Projects/Features/Root/Sources/Main/MainFeature.swift
@@ -54,6 +54,9 @@ public struct MainFeature {
             case .home: return .none
             case .timetable: return .none
             case .myPage: return .none
+            case .path(.element(_, .festival(.seeAllButtonTapped))):
+                state.path.append(.artistList(.init()))
+                return .none
             case .binding: return .none
             case .path: return .none
             }
@@ -80,5 +83,6 @@ extension MainFeature {
     @Reducer
     public enum Path {
         case festival(FestivalFeature)
+        case artistList(ArtistListFeature)
     }
 }

--- a/Projects/Features/Root/Sources/Main/MainView.swift
+++ b/Projects/Features/Root/Sources/Main/MainView.swift
@@ -29,6 +29,7 @@ public struct MainView: View {
         } destination: { store in
             switch store.case {
             case .festival(let store): FestivalView(store: store)
+            case .artistList(let store): ArtistListView(store: store)
             }
         }
     }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호를 명시하세요 (예: Closes #123, Resolves #45) -->
- #25 

---

## ✨ 작업 내용
<!-- 어떤 기능/버그/리팩토링 작업을 했는지 간단하게 작성해주세요 -->
- 아티스트 리스트 UI 구현
- 상단 DAY탭 가로 스크롤뷰로 구현하되, 기기 너비보다 DAY리스트 너비가 작은 경우
스크롤 없이 균등분할하여 중앙정렬 하도록 구현 
- DAY 탭을 누른 경우 해당 DAY의 시작 지점으로 스크롤되게 구현
- 아티스트 리스트를 스크롤하면서 DAY 영역이 바뀌는 걸 감지하여
자동으로 DAY탭이 바뀌도록 구현,
- DAY 탭이 바뀌면 새로 선택된 DAY 탭이 중앙으로 스크롤되게 구현
- 마지막 DAY의 아티스트가 적으면 끝까지 내렸을 때 선택된 DAY를 마지막 날로 해야할지,
그 전날로 해야할지 애매하여, Height를 계산해서 마지막 DAY 텍스트가 스크롤 뷰 상단까지 올 수 있도록
padding을 추가함
- 하단 그라데이션의 Height가 184px이라 최소 bottom padding은 184px

---

## 📸 Showcase
[영상](https://devjungwonlee.notion.site/UI-22681c63297a80e3b001e8a671f4e210)

---

## 📝 참고 사항
<!-- 리뷰어가 이해를 돕기 위한 추가 설명이나 논의 사항이 있다면 여기에 작성하세요 -->
- 이미지 처리는 추후에 구현하겠습니다.
- 아티스트 이름 길이가 달라지면 스크롤할 때 버벅거리는 버그가 존재해서 해결중입니다.
