### PR TITLE
[Feat] 로그인 API 구현

### DIFF
--- a/Projects/App/Sources/DI.swift
+++ b/Projects/App/Sources/DI.swift
@@ -18,3 +18,7 @@ extension NetworkServiceKey: @retroactive DependencyKey {
 extension SampleRepositoryKey: @retroactive DependencyKey {
     public static let liveValue: SampleRepositoryProtocol = SampleRepository()
 }
+
+extension AuthRepositoryKey: @retroactive DependencyKey {
+    public static let liveValue: AuthRepositoryProtocol = AuthRepository()
+}

--- a/Projects/App/Sources/DI.swift
+++ b/Projects/App/Sources/DI.swift
@@ -10,9 +10,14 @@ import Dependencies
 import Domain
 import Data
 import Network
+import Keychain
 
 extension NetworkServiceKey: @retroactive DependencyKey {
     public static let liveValue: NetworkServiceProtocol = NetworkService()
+}
+
+extension KeychainServiceKey: @retroactive DependencyKey {
+    public static let liveValue: KeychainServiceProtocol = KeychainService()
 }
 
 extension SampleRepositoryKey: @retroactive DependencyKey {

--- a/Projects/App/Support/info.plist
+++ b/Projects/App/Support/info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>FirebaseAppDelegateProxyEnabled</key>
-	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -28,8 +26,15 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>Environment</key>
 	<string>$(ENV)</string>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>이미지를 저장하기 위해 사진 앱에 접근합니다.</string>
 	<key>UIApplicationSceneManifest</key>

--- a/Projects/Data/Sources/DeviceID/DeviceIDProvider.swift
+++ b/Projects/Data/Sources/DeviceID/DeviceIDProvider.swift
@@ -1,0 +1,33 @@
+//
+//  DeviceIDProvider.swift
+//  Data
+//
+//  Created by 이정원 on 7/14/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+import Util
+
+struct DeviceIDProvider {
+    @Dependency(\.keychainService) private var keychainService
+    private enum Key { case deviceID }
+    private static let key: String = String(describing: Key.deviceID)
+    private static let shared = DeviceIDProvider()
+    private init() {}
+    
+    static var deviceID: String {
+        let data = shared.keychainService.read(forKey: key)
+        
+        if let data {
+            return data.toString
+        } else {
+            let deviceID = UUID().uuidString
+            if let data = deviceID.data(using: .utf8) {
+                try? shared.keychainService.save(data, forKey: key)
+            }
+            return deviceID
+        }
+    }
+}

--- a/Projects/Data/Sources/Endpoints/AuthEndpoint.swift
+++ b/Projects/Data/Sources/Endpoints/AuthEndpoint.swift
@@ -1,0 +1,31 @@
+//
+//  AuthEndpoint.swift
+//  Data
+//
+//  Created by 이정원 on 7/13/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+enum AuthEndpoint: Endpoint {
+    case signIn(String)
+    
+    var path: String {
+        switch self {
+        case .signIn: "v1/users/login"
+        }
+    }
+    var method: HTTPMethod {
+        switch self {
+        case .signIn: .post
+        }
+    }
+    
+    var queryParameters: Encodable? { nil }
+    
+    var body: Encodable? {
+        switch self {
+        case .signIn(let deviceID):
+            return SignInRequest(deviceID: deviceID)
+        }
+    }
+}

--- a/Projects/Data/Sources/Endpoints/Endpoint.swift
+++ b/Projects/Data/Sources/Endpoints/Endpoint.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Util
 
 public protocol Endpoint {
     var baseURL: String { get }
@@ -27,12 +28,12 @@ public enum HTTPMethod: String {
 
 extension Endpoint {
     var baseURL: String {
-        // TODO: need to implement base url later.
-        return "https://api.sampleapis.com"
+        Constant.URL.base
     }
     
     var headers: [String: String] {
-        // TODO: need to implement header later.
-        return [:]
+        return [
+            "Content-Type": "application/json"
+        ]
     }
 }

--- a/Projects/Data/Sources/KeychainError/KeychainError.swift
+++ b/Projects/Data/Sources/KeychainError/KeychainError.swift
@@ -1,0 +1,27 @@
+//
+//  KeychainError.swift
+//  Data
+//
+//  Created by 이정원 on 7/14/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+public struct KeychainError: Error {
+    public let type: ErrorType
+    public let code: Int?
+    
+    public init(type: ErrorType, code: Int32? = nil) {
+        self.type = type
+        self.code = switch code {
+        case .some(let code): Int(code)
+        case .none: nil
+        }
+    }
+}
+
+extension KeychainError {
+    public enum ErrorType {
+        case save
+        case delete
+    }
+}

--- a/Projects/Data/Sources/Repositories/AuthRepository.swift
+++ b/Projects/Data/Sources/Repositories/AuthRepository.swift
@@ -13,9 +13,14 @@ public struct AuthRepository: AuthRepositoryProtocol {
     @Dependency(\.networkService) private var networkService
     public init() {}
     
-    public func signIn(deviceID: String) async throws -> String? {
-        let endpoint = AuthEndpoint.signIn(deviceID)
+    public var isSignedIn: Bool {
+        TokenStorage.accessToken != nil
+    }
+    
+    public func signIn() async throws {
+        let endpoint = AuthEndpoint.signIn(DeviceIDProvider.deviceID)
         let response: ResponseWrapper<SignInResponse> = try await networkService.request(endpoint: endpoint)
-        return response.result?.token
+        let accessToken = response.result?.token
+        TokenStorage.accessToken = accessToken
     }
 }

--- a/Projects/Data/Sources/Repositories/AuthRepository.swift
+++ b/Projects/Data/Sources/Repositories/AuthRepository.swift
@@ -1,0 +1,21 @@
+//
+//  AuthRepository.swift
+//  Data
+//
+//  Created by 이정원 on 7/13/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Domain
+import Dependencies
+
+public struct AuthRepository: AuthRepositoryProtocol {
+    @Dependency(\.networkService) private var networkService
+    public init() {}
+    
+    public func signIn(deviceID: String) async throws -> String? {
+        let endpoint = AuthEndpoint.signIn(deviceID)
+        let response: ResponseWrapper<SignInResponse> = try await networkService.request(endpoint: endpoint)
+        return response.result?.token
+    }
+}

--- a/Projects/Data/Sources/Requests/SignInRequest.swift
+++ b/Projects/Data/Sources/Requests/SignInRequest.swift
@@ -1,0 +1,15 @@
+//
+//  SignInRequest.swift
+//  Data
+//
+//  Created by 이정원 on 7/14/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+struct SignInRequest: Encodable {
+    let deviceId: String
+    
+    init(deviceID: String) {
+        self.deviceId = deviceID
+    }
+}

--- a/Projects/Data/Sources/Responses/ResponseWrapper.swift
+++ b/Projects/Data/Sources/Responses/ResponseWrapper.swift
@@ -1,0 +1,13 @@
+//
+//  ResponseWrapper.swift
+//  Data
+//
+//  Created by 이정원 on 7/14/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+struct ResponseWrapper<T: Decodable>: Decodable {
+    let resultCode: String?
+    let resultMsg: String?
+    let result: T?
+}

--- a/Projects/Data/Sources/Responses/SignInResponse.swift
+++ b/Projects/Data/Sources/Responses/SignInResponse.swift
@@ -1,0 +1,11 @@
+//
+//  SignInResponse.swift
+//  Data
+//
+//  Created by 이정원 on 7/14/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+struct SignInResponse: Decodable {
+    let token: String?
+}

--- a/Projects/Data/Sources/ServiceProtocols/KeychainServiceProtocol.swift
+++ b/Projects/Data/Sources/ServiceProtocols/KeychainServiceProtocol.swift
@@ -1,0 +1,31 @@
+//
+//  KeychainServiceProtocol.swift
+//  Data
+//
+//  Created by 이정원 on 7/14/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+import Util
+
+public protocol KeychainServiceProtocol {
+    func read(forKey key: String) -> Data?
+    func save(_ data: Data, forKey key: String) throws
+    func delete(forKey key: String) throws
+}
+
+public enum KeychainServiceKey: TestDependencyKey {
+    public static var testValue: KeychainServiceProtocol {
+        unimplemented(KeychainServiceProtocol.self)
+    }
+}
+
+extension DependencyValues {
+    var keychainService: KeychainServiceProtocol {
+        get { self[KeychainServiceKey.self] }
+        set { self[KeychainServiceKey.self] = newValue }
+    }
+}
+

--- a/Projects/Data/Sources/Token/TokenStorage.swift
+++ b/Projects/Data/Sources/Token/TokenStorage.swift
@@ -1,0 +1,36 @@
+//
+//  TokenStorage.swift
+//  Data
+//
+//  Created by 이정원 on 7/14/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Dependencies
+
+struct TokenStorage {
+    @Dependency(\.keychainService) private var keychainService
+    private enum Key { case accessToken }
+    private static let key: String = String(describing: Key.accessToken)
+    private static let shared = TokenStorage()
+    private init() {}
+    
+    static var accessToken: String? {
+        get {
+            let data = shared.keychainService.read(forKey: key)
+            guard let data else { return nil }
+            return String(data: data, encoding: .utf8)
+        }
+        
+        set {
+            if let newValue {
+                guard let newData = newValue.data(using: .utf8) else { return }
+                let data = shared.keychainService.read(forKey: key)
+                if data != nil { try? shared.keychainService.delete(forKey: key) }
+                try? shared.keychainService.save(newData, forKey: key)
+            } else {
+                try? shared.keychainService.delete(forKey: key)
+            }
+        }
+    }
+}

--- a/Projects/DesignSystem/Sources/Timetable/ExtendedTimetableView.swift
+++ b/Projects/DesignSystem/Sources/Timetable/ExtendedTimetableView.swift
@@ -36,6 +36,7 @@ public struct ExtendedTimetableView: View {
             .overlay(alignment: .topLeading) { verticalBorder }
             .overlay(alignment: .topLeading) { horizontalBorder }
         }
+        .background(Color.background1)
     }
 }
 
@@ -43,6 +44,7 @@ private extension ExtendedTimetableView {
     var dayHeaderView: some View {
         Text("25.08.08 (금)")
             .pretendard(style: .title4)
+            .foregroundStyle(Color.white)
             .frame(maxWidth: .infinity)
             .frame(height: 48)
             .background(Color.background2)

--- a/Projects/Domain/Sources/RepositoryProtocols/AuthRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/RepositoryProtocols/AuthRepositoryProtocol.swift
@@ -10,7 +10,8 @@ import Dependencies
 import Util
 
 public protocol AuthRepositoryProtocol {
-    func signIn(deviceID: String) async throws -> String?
+    var isSignedIn: Bool { get }
+    func signIn() async throws
 }
 
 public enum AuthRepositoryKey: TestDependencyKey {

--- a/Projects/Domain/Sources/RepositoryProtocols/AuthRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/RepositoryProtocols/AuthRepositoryProtocol.swift
@@ -1,0 +1,27 @@
+//
+//  AuthRepositoryProtocol.swift
+//  Domain
+//
+//  Created by 이정원 on 7/13/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Dependencies
+import Util
+
+public protocol AuthRepositoryProtocol {
+    func signIn(deviceID: String) async throws -> String?
+}
+
+public enum AuthRepositoryKey: TestDependencyKey {
+    public static var testValue: AuthRepositoryProtocol {
+        unimplemented(AuthRepositoryProtocol.self)
+    }
+}
+
+extension DependencyValues {
+    var authRepository: AuthRepositoryProtocol {
+        get { self[AuthRepositoryKey.self] }
+        set { self[AuthRepositoryKey.self] = newValue }
+    }
+}

--- a/Projects/Domain/Sources/UseCases/AuthUseCase.swift
+++ b/Projects/Domain/Sources/UseCases/AuthUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  AuthUseCase.swift
+//  Domain
+//
+//  Created by 이정원 on 7/13/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Dependencies
+
+public struct AuthUseCase {
+    @Dependency(\.authRepository) private var authRepository
+    
+    public func signIn() async throws {
+        // TODO: fetch device ID
+        let accessToken = try await authRepository.signIn(deviceID: "")
+        // TODO: save access token
+        return
+    }
+}
+
+private enum AuthUseCaseKey: DependencyKey {
+    public static let liveValue = AuthUseCase()
+}
+
+public extension DependencyValues {
+    var authUseCase: AuthUseCase {
+        get { self[AuthUseCaseKey.self] }
+        set { self[AuthUseCaseKey.self] = newValue }
+    }
+}

--- a/Projects/Domain/Sources/UseCases/AuthUseCase.swift
+++ b/Projects/Domain/Sources/UseCases/AuthUseCase.swift
@@ -11,11 +11,12 @@ import Dependencies
 public struct AuthUseCase {
     @Dependency(\.authRepository) private var authRepository
     
+    public var isSignedIn: Bool {
+        authRepository.isSignedIn
+    }
+    
     public func signIn() async throws {
-        // TODO: fetch device ID
-        let accessToken = try await authRepository.signIn(deviceID: "")
-        // TODO: save access token
-        return
+        try await authRepository.signIn()
     }
 }
 

--- a/Projects/Features/Root/Sources/Root/RootFeature.swift
+++ b/Projects/Features/Root/Sources/Root/RootFeature.swift
@@ -29,7 +29,7 @@ public struct RootFeature {
         
         Reduce { state, action in
             switch action {
-            case .path(.splash(.splashDone(let shouldRequestAuthorization))):
+            case .path(.splash(.allTasksDone(let shouldRequestAuthorization))):
                 state.path = switch shouldRequestAuthorization {
                 case true: .permission(.init())
                 case false: .main(.init())

--- a/Projects/Features/Root/Sources/Splash/SplashFeature.swift
+++ b/Projects/Features/Root/Sources/Splash/SplashFeature.swift
@@ -10,16 +10,20 @@ import UIKit
 import ComposableArchitecture
 import Photos
 import UserNotifications
+import Domain
 
 @Reducer
 public struct SplashFeature {
+    @Dependency(\.authUseCase) private var authUseCase
+    
     public struct State {
         
     }
     
     public enum Action {
         case onAppear
-        case splashDone(Bool)
+        case allTasksDone(Bool)
+        case showAlert
     }
     
     public init() {}
@@ -28,21 +32,25 @@ public struct SplashFeature {
             switch action {
             case .onAppear:
                 return .run { send in
-                    await send(checkAuthorizationStatus())
+                    await send(doAllTasks())
                 }
-            case .splashDone: return .none
+            case .allTasksDone: return .none
+            case .showAlert: return .none
             }
         }
     }
 }
 
 private extension SplashFeature {
-    func checkAuthorizationStatus() async -> Action {
-        async let waiting: Void = Task.sleep(for: .seconds(1.5))
-        async let shouldRequestAuthorization = isAutorizationNotDetermined
-        
-        try? await waiting
-        return await .splashDone(shouldRequestAuthorization)
+    func doAllTasks() async -> Action {
+        do {
+            async let signIn: Void = authUseCase.signIn()
+            async let shoulRequestAuthorization = isAutorizationNotDetermined
+            try await signIn
+            return await .allTasksDone(shoulRequestAuthorization)
+        } catch {
+            return .showAlert
+        }
     }
     
     var isAutorizationNotDetermined: Bool {

--- a/Projects/Features/Root/Sources/Splash/SplashFeature.swift
+++ b/Projects/Features/Root/Sources/Splash/SplashFeature.swift
@@ -44,13 +44,21 @@ public struct SplashFeature {
 private extension SplashFeature {
     func doAllTasks() async -> Action {
         do {
-            async let signIn: Void = authUseCase.signIn()
+            async let waiting: Void = Task.sleep(for: .seconds(1.5))
+            async let signIn: Void = signIn()
             async let shoulRequestAuthorization = isAutorizationNotDetermined
+            
             try await signIn
+            try? await waiting
             return await .allTasksDone(shoulRequestAuthorization)
         } catch {
             return .showAlert
         }
+    }
+    
+    func signIn() async throws {
+        if authUseCase.isSignedIn { return }
+        try await authUseCase.signIn()
     }
     
     var isAutorizationNotDetermined: Bool {

--- a/Projects/Keychain/Project.swift
+++ b/Projects/Keychain/Project.swift
@@ -1,0 +1,11 @@
+//
+//  Project.swift
+//  AppManifests
+//
+//  Created by 이정원 on 7/14/25.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project(module: .keychain)

--- a/Projects/Keychain/Sources/KeychainService.swift
+++ b/Projects/Keychain/Sources/KeychainService.swift
@@ -1,0 +1,54 @@
+//
+//  KeychainService.swift
+//  Keychain
+//
+//  Created by 이정원 on 7/14/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Foundation
+import Security
+import Data
+
+public struct KeychainService: KeychainServiceProtocol {
+    public init() {}
+    
+    public func read(forKey key: String) -> Data? {
+        let query = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ] as CFDictionary
+        
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query, &item)
+        guard status == errSecSuccess else { return nil }
+        return item as? Data
+    }
+    
+    public func save(_ data: Data, forKey key: String) throws {
+        let query = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecValueData: data
+        ] as CFDictionary
+        
+        let status = SecItemAdd(query, nil)
+        guard status == errSecSuccess else {
+            throw KeychainError(type: .save, code: status)
+        }
+    }
+    
+    public func delete(forKey key: String) throws {
+        let query = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ] as CFDictionary
+        
+        let status = SecItemDelete(query)
+        guard status == errSecSuccess else {
+            throw KeychainError(type: .delete, code: status)
+        }
+    }
+}

--- a/Projects/Util/Sources/Constant/Constant.swift
+++ b/Projects/Util/Sources/Constant/Constant.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public enum Constant {
     public enum URL {
+        public static let base = ""
         public static let inquiry = "https://forms.gle/qm6g7U9FwKJkJgce8"
     }
     

--- a/Projects/Util/Sources/Extensions/Data+.swift
+++ b/Projects/Util/Sources/Extensions/Data+.swift
@@ -1,0 +1,15 @@
+//
+//  Data+.swift
+//  Util
+//
+//  Created by 이정원 on 7/14/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Foundation
+
+public extension Data {
+    var toString: String {
+        String(data: self, encoding: .utf8) ?? ""
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Dependency.swift
+++ b/Tuist/ProjectDescriptionHelpers/Dependency.swift
@@ -9,7 +9,7 @@ import ProjectDescription
 
 extension Module {
     private static let dependencyInfo: [Module: [Module]] = [
-        .app: [.feature(.root), .network],
+        .app: [.feature(.root), .network, .keychain],
         .feature(.root): [.feature(.home), .feature(.timetable), .feature(.myPage)],
         .feature(.home): [.feature(.base)],
         .feature(.timetable): [.feature(.base)],
@@ -17,7 +17,8 @@ extension Module {
         .feature(.base): [.domain, .designSystem],
         .domain: [.util],
         .data: [.domain],
-        .network: [.data]
+        .network: [.data],
+        .keychain: [.data]
     ]
     
     private static let externalDependencyInfo: [Module: [ExternalModule]] = [

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -16,6 +16,7 @@ public enum Module: Hashable, Sendable {
     
     public var name: String {
         switch self {
+        case .app: ProjectInfo.appName
         case .feature(let module): module.name
         default: "\(self)".capitalized
         }

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -11,6 +11,7 @@ public enum Module: Hashable, Sendable {
     case domain
     case data
     case network
+    case keychain
     case util
     case designSystem
     


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호를 명시하세요 (예: Closes #123, Resolves #45) -->
- #53 

---

## ✨ 작업 내용
<!-- 어떤 기능/버그/리팩토링 작업을 했는지 간단하게 작성해주세요 -->
- 앱 최초 실행시 Device ID 생성 및 키체인 저장
- access token이 키체인에 저장되어있는지 확인 후 없다면 Device ID를 담아 로그인 API 호출
- 로그인 API의 응답에 존재하는 access token을 키체인에 저장
- 앱이 삭제되어도 동일한 Device ID 유지 (키체인에 저장해서 가능)

---

## 📝 참고 사항
<!-- 리뷰어가 이해를 돕기 위한 추가 설명이나 논의 사항이 있다면 여기에 작성하세요 -->
- API Endpoint의 Base URL은 혹시 몰라 숨겼습니다.
- 추후 배포를 위한 심사를 받을 때 HTTPS가 적용되어 있어야 합니다. (현재는 적용X)
