### PR TITLE
[Feat] 페스티벌 좋아요 기능 구현

### DIFF
--- a/Projects/App/Sources/DI.swift
+++ b/Projects/App/Sources/DI.swift
@@ -10,10 +10,15 @@ import Dependencies
 import Domain
 import Data
 import Network
+import Persistence
 import Keychain
 
 extension NetworkServiceKey: @retroactive DependencyKey {
     public static let liveValue: NetworkServiceProtocol = NetworkService()
+}
+
+extension PersistentDataServiceKey: @retroactive DependencyKey {
+    public static let liveValue: PersistentDataServiceProtocol = PersistentDataService()
 }
 
 extension KeychainServiceKey: @retroactive DependencyKey {

--- a/Projects/App/Sources/FestibeeApp.swift
+++ b/Projects/App/Sources/FestibeeApp.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 import Root
 import DesignSystem
+import SwiftData
+import Persistence
 
 @main
 struct FestibeeApp: App {
@@ -30,6 +32,7 @@ struct FestibeeApp: App {
             }
             .preferredColorScheme(.dark)
         }
+        .modelContainer(.festibee)
     }
 }
 

--- a/Projects/Data/Sources/PersistentData/LikedFestival.swift
+++ b/Projects/Data/Sources/PersistentData/LikedFestival.swift
@@ -11,7 +11,7 @@ import SwiftData
 import Domain
 
 @Model
-public final class LikedFestival: Sendable {
+public final class LikedFestival: @unchecked Sendable {
     @Attribute(.unique) public var id: Int
     var creationDate: Date
 

--- a/Projects/Data/Sources/PersistentData/LikedFestival.swift
+++ b/Projects/Data/Sources/PersistentData/LikedFestival.swift
@@ -1,0 +1,28 @@
+//
+//  LikedFestival.swift
+//  Data
+//
+//  Created by 이정원 on 7/22/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Foundation
+import SwiftData
+import Domain
+
+@Model
+public final class LikedFestival: Sendable {
+    @Attribute(.unique) public var id: Int
+    var creationDate: Date
+
+    init(id: Int, creationDate: Date) {
+        self.id = id
+        self.creationDate = creationDate
+    }
+}
+
+extension LikedFestival {
+    var toDomain: Domain.LikedFestival {
+        return .init(id: id, creationDate: creationDate)
+    }
+}

--- a/Projects/Data/Sources/Repositories/FestivalRepository.swift
+++ b/Projects/Data/Sources/Repositories/FestivalRepository.swift
@@ -22,21 +22,19 @@ public struct FestivalRepository: FestivalRepositoryProtocol {
         return result?.compactMap { $0.toDomain } ?? []
     }
     
-    public func fetchLikedFestivals() async throws -> [Domain.LikedFestival] {
-        let likedFestivals: [LikedFestival] = try await persistentDataService.fetchAll()
+    public func fetchLikedFestivals() throws -> [Domain.LikedFestival] {
+        let likedFestivals: [LikedFestival] = try persistentDataService.fetchAll()
         return likedFestivals.map { $0.toDomain }
         
     }
     
-    public func addLikedFestival(festival: Domain.LikedFestival) async throws {
+    public func addLikedFestival(festival: Domain.LikedFestival) throws {
         let likedFestival = LikedFestival(id: festival.id, creationDate: festival.creationDate)
-        try await persistentDataService.insert(likedFestival)
+        try persistentDataService.insert(likedFestival)
     }
     
-    public func deleteLikedFestival(id: Int) async throws {
+    public func deleteLikedFestival(id: Int) throws {
         let predicate = #Predicate<LikedFestival> { $0.id == id }
-        let festival = try await persistentDataService.fetch(predicate: predicate).first
-        guard let festival else { return }
-        try await persistentDataService.delete(festival)
+        try persistentDataService.delete(predicate: predicate)
     }
 }

--- a/Projects/Data/Sources/Repositories/FestivalRepository.swift
+++ b/Projects/Data/Sources/Repositories/FestivalRepository.swift
@@ -6,16 +6,37 @@
 //  Copyright © 2025 Darayo. All rights reserved.
 //
 
+import Foundation
 import Domain
 import Dependencies
 
 public struct FestivalRepository: FestivalRepositoryProtocol {
     @Dependency(\.networkService) private var networkService
+    @Dependency(\.persistentDataService) private var persistentDataService
+    
     public init() {}
     
     public func fetchFestivals() async throws -> [Festival] {
         let endpoint = FestivalEndpoint.fetchFestivals
         let result = try await networkService.request(endpoint: endpoint)
         return result?.compactMap { $0.toDomain } ?? []
+    }
+    
+    public func fetchLikedFestivals() async throws -> [Domain.LikedFestival] {
+        let likedFestivals: [LikedFestival] = try await persistentDataService.fetchAll()
+        return likedFestivals.map { $0.toDomain }
+        
+    }
+    
+    public func addLikedFestival(festival: Domain.LikedFestival) async throws {
+        let likedFestival = LikedFestival(id: festival.id, creationDate: festival.creationDate)
+        try await persistentDataService.insert(likedFestival)
+    }
+    
+    public func deleteLikedFestival(id: Int) async throws {
+        let predicate = #Predicate<LikedFestival> { $0.id == id }
+        let festival = try await persistentDataService.fetch(predicate: predicate).first
+        guard let festival else { return }
+        try await persistentDataService.delete(festival)
     }
 }

--- a/Projects/Data/Sources/ServiceProtocols/PersistentDataServiceProtocol.swift
+++ b/Projects/Data/Sources/ServiceProtocols/PersistentDataServiceProtocol.swift
@@ -12,10 +12,10 @@ import Dependencies
 import Util
 
 public protocol PersistentDataServiceProtocol {
-    @MainActor func fetchAll<T: PersistentModel>() throws -> [T]
-    @MainActor func fetch<T: PersistentModel>(predicate: Predicate<T>) async throws -> [T]
-    @MainActor func insert<T: PersistentModel>(_ data: T) throws
-    @MainActor func delete<T: PersistentModel>(_ data: T) throws
+    func fetchAll<T: PersistentModel>() throws -> [T]
+    func fetch<T: PersistentModel>(predicate: Predicate<T>) throws -> [T]
+    func insert<T: PersistentModel>(_ data: T) throws
+    func delete<T: PersistentModel>(predicate: Predicate<T>) throws
 }
 
 public enum PersistentDataServiceKey: TestDependencyKey {

--- a/Projects/Data/Sources/ServiceProtocols/PersistentDataServiceProtocol.swift
+++ b/Projects/Data/Sources/ServiceProtocols/PersistentDataServiceProtocol.swift
@@ -1,0 +1,32 @@
+//
+//  PersistentDataServiceProtocol.swift
+//  Data
+//
+//  Created by 이정원 on 7/22/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Foundation
+import SwiftData
+import Dependencies
+import Util
+
+public protocol PersistentDataServiceProtocol {
+    @MainActor func fetchAll<T: PersistentModel>() throws -> [T]
+    @MainActor func fetch<T: PersistentModel>(predicate: Predicate<T>) async throws -> [T]
+    @MainActor func insert<T: PersistentModel>(_ data: T) throws
+    @MainActor func delete<T: PersistentModel>(_ data: T) throws
+}
+
+public enum PersistentDataServiceKey: TestDependencyKey {
+    public static var testValue: PersistentDataServiceProtocol {
+        unimplemented(PersistentDataServiceProtocol.self)
+    }
+}
+
+extension DependencyValues {
+    var persistentDataService: PersistentDataServiceProtocol {
+        get { self[PersistentDataServiceKey.self] }
+        set { self[PersistentDataServiceKey.self] = newValue }
+    }
+}

--- a/Projects/Domain/Sources/Models/LikedFestival.swift
+++ b/Projects/Domain/Sources/Models/LikedFestival.swift
@@ -1,0 +1,19 @@
+//
+//  LikedFestival.swift
+//  Domain
+//
+//  Created by 이정원 on 7/22/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Foundation
+
+public struct LikedFestival: Equatable, Hashable {
+    public let id: Int
+    public let creationDate: Date
+    
+    public init(id: Int, creationDate: Date) {
+        self.id = id
+        self.creationDate = creationDate
+    }
+}

--- a/Projects/Domain/Sources/RepositoryProtocols/FestivalRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/RepositoryProtocols/FestivalRepositoryProtocol.swift
@@ -11,6 +11,9 @@ import Util
 
 public protocol FestivalRepositoryProtocol {
     func fetchFestivals() async throws -> [Festival]
+    func fetchLikedFestivals() async throws -> [LikedFestival]
+    func addLikedFestival(festival: LikedFestival) async throws
+    func deleteLikedFestival(id: Int) async throws
 }
 
 public enum FestivalRepositoryKey: TestDependencyKey {

--- a/Projects/Domain/Sources/RepositoryProtocols/FestivalRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/RepositoryProtocols/FestivalRepositoryProtocol.swift
@@ -11,9 +11,9 @@ import Util
 
 public protocol FestivalRepositoryProtocol {
     func fetchFestivals() async throws -> [Festival]
-    func fetchLikedFestivals() async throws -> [LikedFestival]
-    func addLikedFestival(festival: LikedFestival) async throws
-    func deleteLikedFestival(id: Int) async throws
+    func fetchLikedFestivals() throws -> [LikedFestival]
+    func addLikedFestival(festival: LikedFestival) throws
+    func deleteLikedFestival(id: Int) throws
 }
 
 public enum FestivalRepositoryKey: TestDependencyKey {

--- a/Projects/Domain/Sources/UseCases/FestivalUseCase.swift
+++ b/Projects/Domain/Sources/UseCases/FestivalUseCase.swift
@@ -14,6 +14,19 @@ public struct FestivalUseCase {
     public func fetchFestivals() async throws -> [Festival] {
         return try await festivalRepository.fetchFestivals()
     }
+    
+    public func fetchLikedFestivals() async throws -> [LikedFestival] {
+        return try await festivalRepository.fetchLikedFestivals()
+    }
+    
+    public func addLikedFestival(id: Int) async throws {
+        let likedFestival = LikedFestival(id: id, creationDate: .now)
+        return try await festivalRepository.addLikedFestival(festival: likedFestival)
+    }
+    
+    public func deleteLikedFestival(id: Int) async throws {
+        return try await festivalRepository.deleteLikedFestival(id: id)
+    }
 }
 
 private enum FestivalUseCaseKey: DependencyKey {

--- a/Projects/Domain/Sources/UseCases/FestivalUseCase.swift
+++ b/Projects/Domain/Sources/UseCases/FestivalUseCase.swift
@@ -15,17 +15,17 @@ public struct FestivalUseCase {
         return try await festivalRepository.fetchFestivals()
     }
     
-    public func fetchLikedFestivals() async throws -> [LikedFestival] {
-        return try await festivalRepository.fetchLikedFestivals()
+    public func fetchLikedFestivals() throws -> [LikedFestival] {
+        return try festivalRepository.fetchLikedFestivals()
     }
     
-    public func addLikedFestival(id: Int) async throws {
+    public func addLikedFestival(id: Int) throws {
         let likedFestival = LikedFestival(id: id, creationDate: .now)
-        return try await festivalRepository.addLikedFestival(festival: likedFestival)
+        return try festivalRepository.addLikedFestival(festival: likedFestival)
     }
     
-    public func deleteLikedFestival(id: Int) async throws {
-        return try await festivalRepository.deleteLikedFestival(id: id)
+    public func deleteLikedFestival(id: Int) throws {
+        return try festivalRepository.deleteLikedFestival(id: id)
     }
 }
 

--- a/Projects/Features/Home/Sources/Festival/FestivalFeature.swift
+++ b/Projects/Features/Home/Sources/Festival/FestivalFeature.swift
@@ -13,6 +13,7 @@ import Util
 @Reducer
 public struct FestivalFeature {
     @Dependency(\.dismiss) private var dismiss
+    @Dependency(\.festivalUseCase) private var festivalUseCase
     
     @ObservableState
     public struct State {
@@ -21,8 +22,9 @@ public struct FestivalFeature {
         var isFavorite: Bool = false
         var isExpanded: Bool = true
         
-        public init(festival: Festival) {
+        public init(festival: Festival, isFavorite: Bool) {
             self.festival = festival
+            self.isFavorite = isFavorite
         }
         
         var dateString: String {
@@ -49,6 +51,8 @@ public struct FestivalFeature {
         case notificationButtonTapped
         case heartButtonTapped
         case seeAllButtonTapped
+        case likedFestivalsUpdated(Bool)
+        case showAlert
         case navigateToArtistList([Artist])
         case binding(BindingAction<State>)
     }
@@ -65,14 +69,37 @@ public struct FestivalFeature {
                 state.isNotificationOn.toggle()
                 return .none
             case .heartButtonTapped:
-                state.isFavorite.toggle()
-                return .none
+                let id = state.festival.id
+                let isLiked = !state.isFavorite
+                return .run { send in
+                    await send(updateLikedFestivals(id: id, isLiked: isLiked))
+                }
             case .seeAllButtonTapped:
                 let artists = state.festival.artists
                 return .send(.navigateToArtistList(artists))
+            case .likedFestivalsUpdated(let isFavorite):
+                state.isFavorite = isFavorite
+                return .none
+            case .showAlert: return .none
             case .navigateToArtistList: return .none
             case .binding: return .none
             }
+        }
+    }
+}
+
+private extension FestivalFeature {
+    func updateLikedFestivals(id: Int, isLiked: Bool) async -> Action {
+        do {
+            switch isLiked {
+            case true: try await festivalUseCase.addLikedFestival(id: id)
+            case false: try await festivalUseCase.deleteLikedFestival(id: id)
+            }
+            let likedFestivals = try await festivalUseCase.fetchLikedFestivals()
+            let isFavorite = likedFestivals.contains { $0.id == id }
+            return .likedFestivalsUpdated(isFavorite)
+        } catch {
+            return .showAlert
         }
     }
 }

--- a/Projects/Features/Home/Sources/Festival/FestivalFeature.swift
+++ b/Projects/Features/Home/Sources/Festival/FestivalFeature.swift
@@ -51,8 +51,6 @@ public struct FestivalFeature {
         case notificationButtonTapped
         case heartButtonTapped
         case seeAllButtonTapped
-        case likedFestivalsUpdated(Bool)
-        case showAlert
         case navigateToArtistList([Artist])
         case binding(BindingAction<State>)
     }
@@ -71,16 +69,13 @@ public struct FestivalFeature {
             case .heartButtonTapped:
                 let id = state.festival.id
                 let isLiked = !state.isFavorite
-                return .run { send in
-                    await send(updateLikedFestivals(id: id, isLiked: isLiked))
-                }
+                updateLikedFestivals(id: id, isLiked: isLiked)
+                let likedFestivals = fetchLikedFestivals()
+                state.isFavorite = likedFestivals.contains(id)
+                return .none
             case .seeAllButtonTapped:
                 let artists = state.festival.artists
                 return .send(.navigateToArtistList(artists))
-            case .likedFestivalsUpdated(let isFavorite):
-                state.isFavorite = isFavorite
-                return .none
-            case .showAlert: return .none
             case .navigateToArtistList: return .none
             case .binding: return .none
             }
@@ -89,17 +84,15 @@ public struct FestivalFeature {
 }
 
 private extension FestivalFeature {
-    func updateLikedFestivals(id: Int, isLiked: Bool) async -> Action {
-        do {
-            switch isLiked {
-            case true: try await festivalUseCase.addLikedFestival(id: id)
-            case false: try await festivalUseCase.deleteLikedFestival(id: id)
-            }
-            let likedFestivals = try await festivalUseCase.fetchLikedFestivals()
-            let isFavorite = likedFestivals.contains { $0.id == id }
-            return .likedFestivalsUpdated(isFavorite)
-        } catch {
-            return .showAlert
+    func fetchLikedFestivals() -> Set<Int> {
+        let likedFestivals = (try? festivalUseCase.fetchLikedFestivals()) ?? []
+        return Set(likedFestivals.map { $0.id })
+    }
+    
+    func updateLikedFestivals(id: Int, isLiked: Bool) {
+        switch isLiked {
+        case true: try? festivalUseCase.addLikedFestival(id: id)
+        case false: try? festivalUseCase.deleteLikedFestival(id: id)
         }
     }
 }

--- a/Projects/Features/Home/Sources/Home/HomeFeature.swift
+++ b/Projects/Features/Home/Sources/Home/HomeFeature.swift
@@ -54,12 +54,14 @@ public struct HomeFeature {
         case onAppear
         case onRefresh
         case festivalsFetched([Festival], [LikedFestival])
+        case likedFestivalsFetched([LikedFestival])
         case festivalTapped(Festival)
         case heartButtonTapped(Festival)
         case dateSelected(Date)
         case likedFestivalsUpdated([LikedFestival])
         case showAlert
         case binding(BindingAction<State>)
+        case navigateToFestival(Festival, Bool)
     }
     
     public init() {}
@@ -69,8 +71,10 @@ public struct HomeFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                guard state.isLoading else { return .none }
-                return .run { send in await send(fetchFestivals()) }
+                return switch state.isLoading {
+                case true: .run { send in await send(fetchFestivals()) }
+                case false: .run { send in await send( fetchLikedFestivals()) }
+                }
             case .onRefresh:
                 state.isLoading = true
                 return .run { send in await send(fetchFestivals()) }
@@ -79,6 +83,12 @@ public struct HomeFeature {
                 state.likedFestivals = Set(likedFestivals.map { $0.id })
                 state.isLoading = false
                 return .none
+            case .likedFestivalsFetched(let likedFestivals):
+                state.likedFestivals = Set(likedFestivals.map { $0.id })
+                return .none
+            case .festivalTapped(let festival):
+                let isFavorite = state.likedFestivals.contains(festival.id)
+                return .send(.navigateToFestival(festival, isFavorite))
             case .heartButtonTapped(let festival):
                 let id = festival.id
                 let isLiked = !state.likedFestivals.contains(id)
@@ -91,9 +101,9 @@ public struct HomeFeature {
             case .likedFestivalsUpdated(let likedFestivals):
                 state.likedFestivals = Set(likedFestivals.map { $0.id })
                 return .none
-            case .festivalTapped: return .none
             case .showAlert: return .none
             case .binding: return .none
+            case .navigateToFestival: return .none
             }
         }
     }
@@ -105,6 +115,15 @@ private extension HomeFeature {
             async let likedFestivals = festivalUseCase.fetchLikedFestivals()
             async let festivals =  festivalUseCase.fetchFestivals()
             return try await .festivalsFetched(festivals, likedFestivals)
+        } catch {
+            return .showAlert
+        }
+    }
+    
+    func fetchLikedFestivals() async -> Action {
+        do {
+            async let likedFestivals = festivalUseCase.fetchLikedFestivals()
+            return try await .likedFestivalsFetched(likedFestivals)
         } catch {
             return .showAlert
         }

--- a/Projects/Features/Home/Sources/Home/HomeFeature.swift
+++ b/Projects/Features/Home/Sources/Home/HomeFeature.swift
@@ -24,7 +24,7 @@ public struct HomeFeature {
         var displayMode: DisplayMode = .grid
         var isFiltered: Bool = false
         var allFestivals: [Festival] = []
-        var favorites: Set<Festival> = .init()
+        var likedFestivals: Set<Int> = .init()
         var selectedDate: Date?
         var isLoading: Bool = true
         
@@ -38,21 +38,26 @@ public struct HomeFeature {
         }
         
         var favoriteFestivals: [Festival] {
-            allFestivals.filter { favorites.contains($0) }
+            allFestivals.filter { festival in
+                likedFestivals.contains(festival.id)
+            }
         }
         
         var isFavorite: [Bool] {
-            festivals.map { favorites.contains($0) }
+            festivals.map { festival in
+                likedFestivals.contains(festival.id)
+            }
         }
     }
     
     public enum Action: BindableAction {
         case onAppear
         case onRefresh
-        case festivalsFetched([Festival])
+        case festivalsFetched([Festival], [LikedFestival])
         case festivalTapped(Festival)
         case heartButtonTapped(Festival)
         case dateSelected(Date)
+        case likedFestivalsUpdated([LikedFestival])
         case showAlert
         case binding(BindingAction<State>)
     }
@@ -69,21 +74,24 @@ public struct HomeFeature {
             case .onRefresh:
                 state.isLoading = true
                 return .run { send in await send(fetchFestivals()) }
-            case .festivalsFetched(let festivals):
+            case .festivalsFetched(let festivals, let likedFestivals):
                 state.allFestivals = festivals
+                state.likedFestivals = Set(likedFestivals.map { $0.id })
                 state.isLoading = false
                 return .none
-            case .festivalTapped: return .none
             case .heartButtonTapped(let festival):
-                if state.favorites.contains(festival) {
-                    state.favorites.remove(festival)
-                } else {
-                    state.favorites.insert(festival)
+                let id = festival.id
+                let isLiked = !state.likedFestivals.contains(id)
+                return .run { send in
+                    await send(updateLikedFestivals(id: id, isLiked: isLiked))
                 }
-                return .none
             case .dateSelected(let date):
                 state.selectedDate = date
                 return .none
+            case .likedFestivalsUpdated(let likedFestivals):
+                state.likedFestivals = Set(likedFestivals.map { $0.id })
+                return .none
+            case .festivalTapped: return .none
             case .showAlert: return .none
             case .binding: return .none
             }
@@ -94,8 +102,22 @@ public struct HomeFeature {
 private extension HomeFeature {
     func fetchFestivals() async -> Action {
         do {
-            let festivals = try await festivalUseCase.fetchFestivals()
-            return .festivalsFetched(festivals)
+            async let likedFestivals = festivalUseCase.fetchLikedFestivals()
+            async let festivals =  festivalUseCase.fetchFestivals()
+            return try await .festivalsFetched(festivals, likedFestivals)
+        } catch {
+            return .showAlert
+        }
+    }
+    
+    func updateLikedFestivals(id: Int, isLiked: Bool) async -> Action {
+        do {
+            switch isLiked {
+            case true: try await festivalUseCase.addLikedFestival(id: id)
+            case false: try await festivalUseCase.deleteLikedFestival(id: id)
+            }
+            let likedFestivals = try await festivalUseCase.fetchLikedFestivals()
+            return .likedFestivalsUpdated(likedFestivals)
         } catch {
             return .showAlert
         }

--- a/Projects/Features/Home/Sources/Home/HomeFeature.swift
+++ b/Projects/Features/Home/Sources/Home/HomeFeature.swift
@@ -53,12 +53,10 @@ public struct HomeFeature {
     public enum Action: BindableAction {
         case onAppear
         case onRefresh
-        case festivalsFetched([Festival], [LikedFestival])
-        case likedFestivalsFetched([LikedFestival])
+        case festivalsFetched([Festival])
         case festivalTapped(Festival)
         case heartButtonTapped(Festival)
         case dateSelected(Date)
-        case likedFestivalsUpdated([LikedFestival])
         case showAlert
         case binding(BindingAction<State>)
         case navigateToFestival(Festival, Bool)
@@ -71,20 +69,15 @@ public struct HomeFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                return switch state.isLoading {
-                case true: .run { send in await send(fetchFestivals()) }
-                case false: .run { send in await send( fetchLikedFestivals()) }
-                }
+                state.likedFestivals = fetchLikedFestivals()
+                guard state.isLoading else { return .none }
+                return .run { send in await send(fetchFestivals()) }
             case .onRefresh:
                 state.isLoading = true
                 return .run { send in await send(fetchFestivals()) }
-            case .festivalsFetched(let festivals, let likedFestivals):
+            case .festivalsFetched(let festivals):
                 state.allFestivals = festivals
-                state.likedFestivals = Set(likedFestivals.map { $0.id })
                 state.isLoading = false
-                return .none
-            case .likedFestivalsFetched(let likedFestivals):
-                state.likedFestivals = Set(likedFestivals.map { $0.id })
                 return .none
             case .festivalTapped(let festival):
                 let isFavorite = state.likedFestivals.contains(festival.id)
@@ -92,14 +85,11 @@ public struct HomeFeature {
             case .heartButtonTapped(let festival):
                 let id = festival.id
                 let isLiked = !state.likedFestivals.contains(id)
-                return .run { send in
-                    await send(updateLikedFestivals(id: id, isLiked: isLiked))
-                }
+                updateLikedFestivals(id: id, isLiked: isLiked)
+                state.likedFestivals = fetchLikedFestivals()
+                return .none
             case .dateSelected(let date):
                 state.selectedDate = date
-                return .none
-            case .likedFestivalsUpdated(let likedFestivals):
-                state.likedFestivals = Set(likedFestivals.map { $0.id })
                 return .none
             case .showAlert: return .none
             case .binding: return .none
@@ -112,33 +102,22 @@ public struct HomeFeature {
 private extension HomeFeature {
     func fetchFestivals() async -> Action {
         do {
-            async let likedFestivals = festivalUseCase.fetchLikedFestivals()
-            async let festivals =  festivalUseCase.fetchFestivals()
-            return try await .festivalsFetched(festivals, likedFestivals)
+            let festivals = try await festivalUseCase.fetchFestivals()
+            return .festivalsFetched(festivals)
         } catch {
             return .showAlert
         }
     }
     
-    func fetchLikedFestivals() async -> Action {
-        do {
-            async let likedFestivals = festivalUseCase.fetchLikedFestivals()
-            return try await .likedFestivalsFetched(likedFestivals)
-        } catch {
-            return .showAlert
-        }
+    func fetchLikedFestivals() -> Set<Int> {
+        let likedFestivals = (try? festivalUseCase.fetchLikedFestivals()) ?? []
+        return Set(likedFestivals.map { $0.id })
     }
     
-    func updateLikedFestivals(id: Int, isLiked: Bool) async -> Action {
-        do {
-            switch isLiked {
-            case true: try await festivalUseCase.addLikedFestival(id: id)
-            case false: try await festivalUseCase.deleteLikedFestival(id: id)
-            }
-            let likedFestivals = try await festivalUseCase.fetchLikedFestivals()
-            return .likedFestivalsUpdated(likedFestivals)
-        } catch {
-            return .showAlert
+    func updateLikedFestivals(id: Int, isLiked: Bool) {
+        switch isLiked {
+        case true: try? festivalUseCase.addLikedFestival(id: id)
+        case false: try? festivalUseCase.deleteLikedFestival(id: id)
         }
     }
 }

--- a/Projects/Features/Root/Sources/Main/MainFeature.swift
+++ b/Projects/Features/Root/Sources/Main/MainFeature.swift
@@ -51,8 +51,8 @@ public struct MainFeature {
         
         Reduce { state, action in
             switch action {
-            case .home(.festivalTapped(let festival)):
-                state.path.append(.festival(.init(festival: festival)))
+            case let .home(.navigateToFestival(festival, isFavorite)):
+                state.path.append(.festival(.init(festival: festival, isFavorite: isFavorite)))
                 return .none
             case .myPage(.menuTapped(.inquiry)):
                 state.url = URL(string: Constant.URL.inquiry)

--- a/Projects/Persistence/Project.swift
+++ b/Projects/Persistence/Project.swift
@@ -1,0 +1,11 @@
+//
+//  Project.swift
+//  AppManifests
+//
+//  Created by 이정원 on 6/1/25.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project(module: .persistence)

--- a/Projects/Persistence/Sources/PersistentDataService/PersistentDataService.swift
+++ b/Projects/Persistence/Sources/PersistentDataService/PersistentDataService.swift
@@ -14,27 +14,29 @@ public struct PersistentDataService: PersistentDataServiceProtocol {
     private let container = ModelContainer.festibee
     public init() {}
 
-    @MainActor public func fetchAll<T: PersistentModel>() throws -> [T] {
-        let context = container.mainContext
+    public func fetchAll<T: PersistentModel>() throws -> [T] {
+        let context = ModelContext(container)
         let descriptor = FetchDescriptor<T>(predicate: nil)
         return try context.fetch(descriptor)
     }
     
-    @MainActor public func fetch<T: PersistentModel>(predicate: Predicate<T>) async throws -> [T] {
-        let context = container.mainContext
+    public func fetch<T: PersistentModel>(predicate: Predicate<T>) throws -> [T] {
+        let context = ModelContext(container)
         let descriptor = FetchDescriptor<T>(predicate: predicate)
         return try context.fetch(descriptor)
     }
 
-    @MainActor public func insert<T: PersistentModel>(_ data: T) throws {
-        let context = container.mainContext
+    public func insert<T: PersistentModel>(_ data: T) throws {
+        let context = ModelContext(container)
         context.insert(data)
         try context.save()
     }
 
-    @MainActor public func delete<T: PersistentModel>(_ data: T) throws {
-        let context = container.mainContext
-        context.delete(data)
+    public func delete<T: PersistentModel>(predicate: Predicate<T>) throws {
+        let context = ModelContext(container)
+        let descriptor = FetchDescriptor<T>(predicate: predicate)
+        let data = try context.fetch(descriptor).first
+        if let data { context.delete(data) }
         try context.save()
     }
 }

--- a/Projects/Persistence/Sources/PersistentDataService/PersistentDataService.swift
+++ b/Projects/Persistence/Sources/PersistentDataService/PersistentDataService.swift
@@ -1,0 +1,53 @@
+//
+//  PersistentDataService.swift
+//  Persistence
+//
+//  Created by 이정원 on 7/22/25.
+//  Copyright © 2025 Darayo. All rights reserved.
+//
+
+import Foundation
+import SwiftData
+import Data
+
+public struct PersistentDataService: PersistentDataServiceProtocol {
+    private let container = ModelContainer.festibee
+    public init() {}
+
+    @MainActor public func fetchAll<T: PersistentModel>() throws -> [T] {
+        let context = container.mainContext
+        let descriptor = FetchDescriptor<T>(predicate: nil)
+        return try context.fetch(descriptor)
+    }
+    
+    @MainActor public func fetch<T: PersistentModel>(predicate: Predicate<T>) async throws -> [T] {
+        let context = container.mainContext
+        let descriptor = FetchDescriptor<T>(predicate: predicate)
+        return try context.fetch(descriptor)
+    }
+
+    @MainActor public func insert<T: PersistentModel>(_ data: T) throws {
+        let context = container.mainContext
+        context.insert(data)
+        try context.save()
+    }
+
+    @MainActor public func delete<T: PersistentModel>(_ data: T) throws {
+        let context = container.mainContext
+        context.delete(data)
+        try context.save()
+    }
+}
+
+public extension ModelContainer {
+    static let festibee: ModelContainer = {
+        let schema = Schema([LikedFestival.self])
+
+        do {
+            let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+            return try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            fatalError("Unable to create Model Container")
+        }
+    }()
+}

--- a/Tuist/ProjectDescriptionHelpers/Dependency.swift
+++ b/Tuist/ProjectDescriptionHelpers/Dependency.swift
@@ -9,7 +9,7 @@ import ProjectDescription
 
 extension Module {
     private static let dependencyInfo: [Module: [Module]] = [
-        .app: [.feature(.root), .network, .keychain],
+        .app: [.feature(.root), .network, .persistence, .keychain],
         .feature(.root): [.feature(.home), .feature(.timetable), .feature(.myPage)],
         .feature(.home): [.feature(.base)],
         .feature(.timetable): [.feature(.base)],
@@ -18,6 +18,7 @@ extension Module {
         .domain: [.util],
         .data: [.domain],
         .network: [.data],
+        .persistence: [.data],
         .keychain: [.data]
     ]
     

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -11,6 +11,7 @@ public enum Module: Hashable, Sendable {
     case domain
     case data
     case network
+    case persistence
     case keychain
     case util
     case designSystem


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호를 명시하세요 (예: Closes #123, Resolves #45) -->
- #70 

---

## ✨ 작업 내용
<!-- 어떤 기능/버그/리팩토링 작업을 했는지 간단하게 작성해주세요 -->
- 홈 그리드 뷰와 페스티벌 상세 화면의 하트 버튼을 눌렀을 때 좋아요 정보를 저장/삭제 하도록
로컬 데이터베이스를 구현하였습니다.

---

## 📝 참고 사항
<!-- 리뷰어가 이해를 돕기 위한 추가 설명이나 논의 사항이 있다면 여기에 작성하세요 -->
- 후속 작업으로 좋아요 버튼을 눌렀을 때 알림 설정도 가능하도록 이어서 구현하겠습니다.
