### PR TITLE
[FSTB-119] 네트워크 에러 구분, 팝업 터치 로직 구현

### DIFF
--- a/Projects/Data/Sources/Endpoints/Endpoint.swift
+++ b/Projects/Data/Sources/Endpoints/Endpoint.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Util
+import Domain
 
 public protocol Endpoint {
     associatedtype Response

--- a/Projects/Domain/Sources/Models/NetworkError.swift
+++ b/Projects/Domain/Sources/Models/NetworkError.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2025 Darayo. All rights reserved.
 //
 
-public struct NetworkError: Error {
+public struct NetworkError: Error, Equatable {
     public let type: ErrorType
     public let path: String?
     public let code: Int?

--- a/Projects/Domain/Sources/Models/NetworkError.swift
+++ b/Projects/Domain/Sources/Models/NetworkError.swift
@@ -35,9 +35,10 @@ extension NetworkError {
         case unauthorized
         case forbidden
         case notFound
-        case timeout
         case client
         case server
+        case noInternet
+        case timeout
         case others
         case responseDecoding
         case unknown

--- a/Projects/Features/Base/Sources/Alert/AlertInfo+.swift
+++ b/Projects/Features/Base/Sources/Alert/AlertInfo+.swift
@@ -10,6 +10,20 @@ import SwiftUI
 import DesignSystem
 
 public extension AlertInfo {
+    static var noInternet: Self {
+        let message = """
+        WIFI 또는 모바일 네트워크
+        연결 상태를 확인해주세요.
+        """
+        
+        return .init(
+            icon: .iconError,
+            title: "연결이 원활하지 않아요",
+            message: message,
+            buttonTitle: "확인"
+        )
+    }
+    
     static var error: Self {
         let message = """
         일시적인 오류가 발생했어요. 

--- a/Projects/Features/Base/Sources/Alert/AlertInfo+.swift
+++ b/Projects/Features/Base/Sources/Alert/AlertInfo+.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import DesignSystem
+import Domain
 
 public extension AlertInfo {
     static var noInternet: Self {
@@ -24,16 +25,25 @@ public extension AlertInfo {
         )
     }
     
-    static var error: Self {
+    static func error(
+        _ error: NetworkError,
+        buttonTitle: String
+    ) -> Self {
+        let code = switch error.code {
+        case .some(let code): "(\(code))"
+        case .none: ""
+        }
+        
         let message = """
-        일시적인 오류가 발생했어요. 
+        일시적인 오류\(code)가 발생했어요.
+        다시 시도해주세요.
         """
         
         return .init(
             icon: .iconError,
             title: "잠시 오류가 발생했어요",
             message: message,
-            buttonTitle: "확인"
+            buttonTitle: buttonTitle
         )
     }
     

--- a/Projects/Features/Base/Sources/Alert/CustomAlert.swift
+++ b/Projects/Features/Base/Sources/Alert/CustomAlert.swift
@@ -13,9 +13,11 @@ public struct CustomAlert<AlertCase: AlertPresentable> {
     @ObservableState
     public struct State: Equatable {
         let alertCase: AlertCase
+        let canDismiss: Bool
         
-        public init(_ alertCase: AlertCase) {
+        public init(_ alertCase: AlertCase, _ canDismiss: Bool = true) {
             self.alertCase = alertCase
+            self.canDismiss = canDismiss
         }
     }
     

--- a/Projects/Features/Base/Sources/Alert/CustomAlertViewModifier.swift
+++ b/Projects/Features/Base/Sources/Alert/CustomAlertViewModifier.swift
@@ -27,7 +27,10 @@ struct CustomAlertViewModifier<AlertCase: AlertPresentable>: ViewModifier {
                 Color.background1
                     .opacity(0.2)
                     .ignoresSafeArea(.all)
-                    .onTapGesture { self.item = nil }
+                    .onTapGesture {
+                        guard item.canDismiss else { return }
+                        self.item = nil
+                    }
             
                 customAlertView(store: item)
             }
@@ -36,6 +39,7 @@ struct CustomAlertViewModifier<AlertCase: AlertPresentable>: ViewModifier {
     
     private func customAlertView(store: StoreOf<CustomAlert<AlertCase>>) -> some View {
         let alertInfo = store.alertCase.alertInfo
+        let closeAction: (() -> Void)? = store.canDismiss ? { item = nil } : nil
         
         return CustomAlertView(
             icon: alertInfo.icon,
@@ -45,13 +49,13 @@ struct CustomAlertViewModifier<AlertCase: AlertPresentable>: ViewModifier {
             upperText: alertInfo.box?.upperText,
             highlightText: alertInfo.box?.highlightText,
             lowerText: alertInfo.box?.lowerText,
-            buttonTitle: alertInfo.buttonTitle
-        ) {
-            store.send(.buttonTapped(store.alertCase))
-            item = nil
-        } closeAction: {
-            item = nil
-        }
+            buttonTitle: alertInfo.buttonTitle,
+            action: {
+                store.send(.buttonTapped(store.alertCase))
+                item = nil
+            },
+            closeAction: closeAction
+        )
         .background(Color.clear)
     }
 }

--- a/Projects/Features/Home/Sources/Festival/FestivalFeature.swift
+++ b/Projects/Features/Home/Sources/Festival/FestivalFeature.swift
@@ -17,7 +17,15 @@ public struct FestivalFeature {
     public enum AlertCase: Equatable {
         case authorization
         case agreement
-        case error(NetworkError.ErrorType)
+        case failedToFetch(NetworkError)
+        case failedToUpdate(NetworkError)
+        
+        var canDismiss: Bool {
+            switch self {
+            case .failedToFetch: return false
+            default: return true
+            }
+        }
     }
     
     @Dependency(\.dismiss) private var dismiss
@@ -72,7 +80,6 @@ public struct FestivalFeature {
         case updateNotificationAgreement(Bool)
         case updateNotification(Bool)
         case seeAllButtonTapped
-        case showError(NetworkError?)
         case showAlert(AlertCase)
         case notificationUpdated(Bool)
         case notificationAgreementUpdated(Bool)
@@ -136,7 +143,7 @@ public struct FestivalFeature {
                 return .none
             case .updateNotification(let isEnabled):
                 return .run { [state] send in
-                    await send(updateNotificaion(state, isEnabled: isEnabled))
+                    await updateNotificaion(state, send, isEnabled: isEnabled)
                 }
             case .seeAllButtonTapped:
                 let artists = state.festival.artists
@@ -147,11 +154,8 @@ public struct FestivalFeature {
             case .notificationAgreementUpdated(let isAccepted):
                 state.isAccepted = isAccepted
                 return .none
-            case .showError(let networkError):
-                guard let networkError else { return .none }
-                return .send(.showAlert(.error(networkError.type)))
             case .showAlert(let alertCase):
-                state.alert = .init(alertCase)
+                state.alert = .init(alertCase, alertCase.canDismiss)
                 return .none
             case .alert(.presented(.buttonTapped(.authorization))):
                 state.hasTappedButton = true
@@ -159,6 +163,8 @@ public struct FestivalFeature {
                 return .none
             case .alert(.presented(.buttonTapped(.agreement))):
                 return .send(.navigateToMyPage)
+            case .alert(.presented(.buttonTapped(.failedToFetch))):
+                return .send(.backButtonTapped)
             case .alert: return .none
             case .navigateToArtistList: return .none
             case .navigateToMyPage: return .none
@@ -182,7 +188,8 @@ private extension FestivalFeature {
             await send(.authorizationChecked(isAuthorized))
         } catch {
             let networkError = error as? NetworkError
-            await send(.showError(networkError))
+            guard let networkError else { return }
+            await send(.showAlert(.failedToFetch(networkError)))
         }
     }
     
@@ -221,14 +228,19 @@ private extension FestivalFeature {
         return try await notificationUseCase.fetchNotificationState()
     }
     
-    func updateNotificaion(_ state: State, isEnabled: Bool) async -> Action {
+    func updateNotificaion(
+        _ state: State,
+        _ send: Send<Action>,
+        isEnabled: Bool
+    ) async {
         do {
             let id = state.festival.id
             try await notificationUseCase.updateNotification(id: id, isEnabled: isEnabled)
-            return .notificationUpdated(isEnabled)
+            await send(.notificationUpdated(isEnabled))
         } catch(let error) {
             let networkError = error as? NetworkError
-            return .showError(networkError)
+            guard let networkError else { return }
+            await send(.showAlert(.failedToUpdate((networkError))))
         }
     }
     
@@ -236,9 +248,10 @@ private extension FestivalFeature {
         do {
             try await notificationUseCase.updateNotification(isEnabled: isEnabled)
             await send(.notificationAgreementUpdated(isEnabled))
-        } catch {
+        } catch(let error) {
             let networkError = error as? NetworkError
-            await send(.showError(networkError))
+            guard let networkError else { return }
+            await send(.showAlert(.failedToUpdate((networkError))))
         }
     }
 }

--- a/Projects/Features/Home/Sources/Festival/FestivalFeature.swift
+++ b/Projects/Features/Home/Sources/Festival/FestivalFeature.swift
@@ -14,10 +14,10 @@ import Base
 
 @Reducer
 public struct FestivalFeature {
-    public enum AlertCase {
+    public enum AlertCase: Equatable {
         case authorization
         case agreement
-        case error
+        case error(NetworkError.ErrorType)
     }
     
     @Dependency(\.dismiss) private var dismiss
@@ -72,6 +72,7 @@ public struct FestivalFeature {
         case updateNotificationAgreement(Bool)
         case updateNotification(Bool)
         case seeAllButtonTapped
+        case showError(NetworkError?)
         case showAlert(AlertCase)
         case notificationUpdated(Bool)
         case notificationAgreementUpdated(Bool)
@@ -146,6 +147,9 @@ public struct FestivalFeature {
             case .notificationAgreementUpdated(let isAccepted):
                 state.isAccepted = isAccepted
                 return .none
+            case .showError(let networkError):
+                guard let networkError else { return .none }
+                return .send(.showAlert(.error(networkError.type)))
             case .showAlert(let alertCase):
                 state.alert = .init(alertCase)
                 return .none
@@ -177,7 +181,8 @@ private extension FestivalFeature {
             try await send(.notificationAgreementStateFetched(isAccepted))
             await send(.authorizationChecked(isAuthorized))
         } catch {
-            await send(.showAlert(.error))
+            let networkError = error as? NetworkError
+            await send(.showError(networkError))
         }
     }
     
@@ -221,8 +226,9 @@ private extension FestivalFeature {
             let id = state.festival.id
             try await notificationUseCase.updateNotification(id: id, isEnabled: isEnabled)
             return .notificationUpdated(isEnabled)
-        } catch {
-            return .showAlert(.error)
+        } catch(let error) {
+            let networkError = error as? NetworkError
+            return .showError(networkError)
         }
     }
     
@@ -231,7 +237,8 @@ private extension FestivalFeature {
             try await notificationUseCase.updateNotification(isEnabled: isEnabled)
             await send(.notificationAgreementUpdated(isEnabled))
         } catch {
-            await send(.showAlert(.error))
+            let networkError = error as? NetworkError
+            await send(.showError(networkError))
         }
     }
 }

--- a/Projects/Features/Home/Sources/Festival/FestivalView.swift
+++ b/Projects/Features/Home/Sources/Festival/FestivalView.swift
@@ -11,6 +11,7 @@ import ComposableArchitecture
 import DesignSystem
 import Base
 import Kingfisher
+import Domain
 
 public struct FestivalView: View {
     @Bindable private var store: StoreOf<FestivalFeature>
@@ -242,8 +243,15 @@ extension FestivalFeature.AlertCase: AlertPresentable {
         switch self {
         case .authorization: return .authorization
         case .agreement: return .agreement
-        case .error(.noInternet): return .noInternet
-        case .error: return .error
+        case .failedToFetch(let error): return alertInfo(error)
+        case .failedToUpdate(let error): return alertInfo(error)
+        }
+    }
+    
+    private func alertInfo(_ error: NetworkError) -> AlertInfo {
+        switch error.type {
+        case .noInternet: return .noInternet
+        default: return .error(error, buttonTitle: "확인")
         }
     }
 }

--- a/Projects/Features/Home/Sources/Festival/FestivalView.swift
+++ b/Projects/Features/Home/Sources/Festival/FestivalView.swift
@@ -242,6 +242,7 @@ extension FestivalFeature.AlertCase: AlertPresentable {
         switch self {
         case .authorization: return .authorization
         case .agreement: return .agreement
+        case .error(.noInternet): return .noInternet
         case .error: return .error
         }
     }

--- a/Projects/Features/Home/Sources/Home/HomeFeature.swift
+++ b/Projects/Features/Home/Sources/Home/HomeFeature.swift
@@ -18,7 +18,7 @@ public struct HomeFeature {
     @Dependency(\.notificationUseCase) private var notificationUseCase
     
     public enum AlertCase: Equatable {
-        case error(NetworkError.ErrorType)
+        case error(NetworkError)
     }
     
     @ObservableState
@@ -85,7 +85,7 @@ public struct HomeFeature {
             case .myPageButtonTapped: return .none
             case .showError(let networkError):
                 guard let networkError else { return .none }
-                return .send(.showAlert(.error(networkError.type)))
+                return .send(.showAlert(.error(networkError)))
             case .showAlert:
                 state.isLoading = false
                 return .none

--- a/Projects/Features/Home/Sources/Home/HomeFeature.swift
+++ b/Projects/Features/Home/Sources/Home/HomeFeature.swift
@@ -17,8 +17,8 @@ public struct HomeFeature {
     @Dependency(\.festivalUseCase) private var festivalUseCase
     @Dependency(\.notificationUseCase) private var notificationUseCase
     
-    public enum AlertCase {
-        case error
+    public enum AlertCase: Equatable {
+        case error(NetworkError.ErrorType)
     }
     
     @ObservableState
@@ -54,6 +54,7 @@ public struct HomeFeature {
         case festivalTapped(Festival)
         case heartButtonTapped(Festival)
         case myPageButtonTapped
+        case showError(NetworkError?)
         case showAlert(AlertCase)
         case alert(AlertCase)
         case navigateToFestival(Festival, Bool)
@@ -82,6 +83,9 @@ public struct HomeFeature {
                 state.likedFestivals = fetchLikedFestivals()
                 return .none
             case .myPageButtonTapped: return .none
+            case .showError(let networkError):
+                guard let networkError else { return .none }
+                return .send(.showAlert(.error(networkError.type)))
             case .showAlert:
                 state.isLoading = false
                 return .none
@@ -97,8 +101,9 @@ private extension HomeFeature {
         do {
             let festivals = try await festivalUseCase.fetchFestivals()
             return .festivalsFetched(festivals)
-        } catch {
-            return .showAlert(.error)
+        } catch(let error) {
+            let networkError = error as? NetworkError
+            return .showError(networkError)
         }
     }
     

--- a/Projects/Features/Home/Sources/Home/HomeGridView.swift
+++ b/Projects/Features/Home/Sources/Home/HomeGridView.swift
@@ -26,7 +26,7 @@ struct HomeGridView: View {
                 .animation(.easeInOut(duration: 0.3), value: store.festivals)
                 .renderedIf(shouldShowGridView)
             
-            emptyView
+            Color.background1
                 .renderedIf(shouldShowEmptyView)
         }
         .animation(.easeInOut(duration: 0.3), value: store.festivals.isEmpty)
@@ -61,25 +61,5 @@ private extension HomeGridView {
             .padding(.bottom, 24)
             .padding(.top, 12)
         }
-    }
-    
-    var emptyView: some View {
-        VStack(spacing: 0) {
-            Image.star
-            
-            Text("아직 좋아요한 페스티벌이 없어요!")
-                .pretendard(style: .title2)
-                .foregroundStyle(Color.white)
-                .padding(.top, 22)
-            
-            Text("관심있는 페스티벌을\n좋아요하고, 소식을 받아보세요 :)")
-                .pretendard(style: .body4)
-                .multilineTextAlignment(.center)
-                .foregroundStyle(Color.grey4)
-                .padding(.top, 10)
-        }
-        .padding(.bottom, 10)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.bottom, 24)
     }
 }

--- a/Projects/Features/Home/Sources/Home/HomeView.swift
+++ b/Projects/Features/Home/Sources/Home/HomeView.swift
@@ -59,8 +59,11 @@ private extension HomeView {
 extension HomeFeature.AlertCase: AlertPresentable {
     public var alertInfo: AlertInfo {
         switch self {
-        case .error(.noInternet): return .noInternet
-        case .error: return .error
+        case .error(let error):
+            switch error.type {
+            case .noInternet: return .noInternet
+            default: return .error(error, buttonTitle: "새로 고침")
+            }
         }
     }
 }

--- a/Projects/Features/Home/Sources/Home/HomeView.swift
+++ b/Projects/Features/Home/Sources/Home/HomeView.swift
@@ -59,6 +59,7 @@ private extension HomeView {
 extension HomeFeature.AlertCase: AlertPresentable {
     public var alertInfo: AlertInfo {
         switch self {
+        case .error(.noInternet): return .noInternet
         case .error: return .error
         }
     }

--- a/Projects/Features/Home/Sources/Home/HomeView.swift
+++ b/Projects/Features/Home/Sources/Home/HomeView.swift
@@ -62,7 +62,7 @@ extension HomeFeature.AlertCase: AlertPresentable {
         case .error(let error):
             switch error.type {
             case .noInternet: return .noInternet
-            default: return .error(error, buttonTitle: "새로 고침")
+            default: return .error(error, buttonTitle: "확인")
             }
         }
     }

--- a/Projects/Features/MyPage/Sources/LikedFestivals/LikedFestivalsFeature.swift
+++ b/Projects/Features/MyPage/Sources/LikedFestivals/LikedFestivalsFeature.swift
@@ -16,8 +16,8 @@ public struct LikedFestivalsFeature {
     @Dependency(\.dismiss) private var dismiss
     @Dependency(\.festivalUseCase) private var festivalUseCase
     
-    public enum AlertCase {
-        case error
+    public enum AlertCase: Equatable {
+        case error(NetworkError.ErrorType)
     }
     
     @ObservableState
@@ -32,6 +32,7 @@ public struct LikedFestivalsFeature {
     public enum Action {
         case onAppear
         case festivalsFetched([Festival])
+        case showError(NetworkError?)
         case showAlert(AlertCase)
         case backButtonTapped
         case festivalTapped(Festival)
@@ -68,6 +69,9 @@ public struct LikedFestivalsFeature {
                 updateLikedFestivals(festival.id, isFavorite: isFavorite)
                 state.isFavorite[index].toggle()
                 return .none
+            case .showError(let networkError):
+                guard let networkError else { return .none }
+                return .send(.showAlert(.error(networkError.type)))
             case .showAlert(let alertCase):
                 state.isLoading = false
                 state.alert = .init(alertCase)
@@ -92,7 +96,8 @@ private extension LikedFestivalsFeature {
             let likedFestivals = festivals.filter { ids.contains($0.id) }
             return .festivalsFetched(likedFestivals)
         } catch {
-            return .showAlert(.error)
+            let networkError = error as? NetworkError
+            return .showError(networkError)
         }
     }
     

--- a/Projects/Features/MyPage/Sources/LikedFestivals/LikedFestivalsFeature.swift
+++ b/Projects/Features/MyPage/Sources/LikedFestivals/LikedFestivalsFeature.swift
@@ -17,7 +17,7 @@ public struct LikedFestivalsFeature {
     @Dependency(\.festivalUseCase) private var festivalUseCase
     
     public enum AlertCase: Equatable {
-        case error(NetworkError.ErrorType)
+        case error(NetworkError)
     }
     
     @ObservableState
@@ -71,11 +71,13 @@ public struct LikedFestivalsFeature {
                 return .none
             case .showError(let networkError):
                 guard let networkError else { return .none }
-                return .send(.showAlert(.error(networkError.type)))
+                return .send(.showAlert(.error(networkError)))
             case .showAlert(let alertCase):
                 state.isLoading = false
-                state.alert = .init(alertCase)
+                state.alert = .init(alertCase, false)
                 return .none
+            case .alert(.presented(.buttonTapped(.error))):
+                return .send(.backButtonTapped)
             case .backButtonTapped:
                 return .run { _ in await self.dismiss() }
             case .navigateToFestival: return .none

--- a/Projects/Features/MyPage/Sources/LikedFestivals/LikedFestivalsView.swift
+++ b/Projects/Features/MyPage/Sources/LikedFestivals/LikedFestivalsView.swift
@@ -42,8 +42,11 @@ public struct LikedFestivalsView: View {
 extension LikedFestivalsFeature.AlertCase: AlertPresentable {
     public var alertInfo: AlertInfo {
         switch self {
-        case .error(.noInternet): return .noInternet
-        case .error: return .error
+        case .error(let error):
+            switch error.type {
+            case .noInternet: return .noInternet
+            default: return .error(error, buttonTitle: "확인")
+            }
         }
     }
 }

--- a/Projects/Features/MyPage/Sources/LikedFestivals/LikedFestivalsView.swift
+++ b/Projects/Features/MyPage/Sources/LikedFestivals/LikedFestivalsView.swift
@@ -42,6 +42,7 @@ public struct LikedFestivalsView: View {
 extension LikedFestivalsFeature.AlertCase: AlertPresentable {
     public var alertInfo: AlertInfo {
         switch self {
+        case .error(.noInternet): return .noInternet
         case .error: return .error
         }
     }

--- a/Projects/Features/MyPage/Sources/MyPage/MyPageFeature.swift
+++ b/Projects/Features/MyPage/Sources/MyPage/MyPageFeature.swift
@@ -19,8 +19,8 @@ public struct MyPageFeature {
     @Dependency(\.festivalUseCase) private var festivalUseCase
     @Dependency(\.dismiss) private var dismiss
     
-    public enum AlertCase {
-        case error
+    public enum AlertCase: Equatable {
+        case error(NetworkError.ErrorType)
         case authorization
     }
     
@@ -58,6 +58,7 @@ public struct MyPageFeature {
         case setToggle(Bool)
         case likedFestivalsButtonTapped
         case subscribedFestivalsButtonTapped
+        case showError(NetworkError?)
         case showAlert(AlertCase)
         case menuTapped(Menu)
         case backButtonTapped
@@ -119,6 +120,9 @@ public struct MyPageFeature {
                 return .none
             case .backButtonTapped:
                 return .run { _ in await dismiss() }
+            case .showError(let networkError):
+                guard let networkError else { return .none }
+                return .send(.showAlert(.error(networkError.type)))
             case .showAlert(let alertCase):
                 state.alert = .init(alertCase)
                 return .none
@@ -153,7 +157,8 @@ private extension MyPageFeature {
             await send(.authorizationChecked(isAuthorized))
             await send(.allFetched)
         } catch {
-            await send(.showAlert(.error))
+            let networkError = error as? NetworkError
+            await send(.showError(networkError))
         }
     }
     
@@ -178,7 +183,8 @@ private extension MyPageFeature {
             try await notificationUseCase.updateNotification(isEnabled: isEnabled)
             return .setToggle(isEnabled)
         } catch {
-            return .showAlert(.error)
+            let networkError = error as? NetworkError
+            return .showError(networkError)
         }
     }
 }

--- a/Projects/Features/MyPage/Sources/MyPage/MyPageFeature.swift
+++ b/Projects/Features/MyPage/Sources/MyPage/MyPageFeature.swift
@@ -20,7 +20,7 @@ public struct MyPageFeature {
     @Dependency(\.dismiss) private var dismiss
     
     public enum AlertCase: Equatable {
-        case error(NetworkError.ErrorType)
+        case error(NetworkError)
         case authorization
     }
     
@@ -122,7 +122,7 @@ public struct MyPageFeature {
                 return .run { _ in await dismiss() }
             case .showError(let networkError):
                 guard let networkError else { return .none }
-                return .send(.showAlert(.error(networkError.type)))
+                return .send(.showAlert(.error(networkError)))
             case .showAlert(let alertCase):
                 state.alert = .init(alertCase)
                 return .none
@@ -157,8 +157,6 @@ private extension MyPageFeature {
             await send(.authorizationChecked(isAuthorized))
             await send(.allFetched)
         } catch {
-            let networkError = error as? NetworkError
-            await send(.showError(networkError))
         }
     }
     

--- a/Projects/Features/MyPage/Sources/MyPage/MyPageView.swift
+++ b/Projects/Features/MyPage/Sources/MyPage/MyPageView.swift
@@ -264,8 +264,11 @@ extension MyPageFeature.AlertCase: AlertPresentable {
     public var alertInfo: AlertInfo {
         switch self {
         case .authorization: return .authorization
-        case .error(.noInternet): return .noInternet
-        case .error: return .error
+        case .error(let error):
+            switch error.type {
+            case .noInternet: return .noInternet
+            default: return .error(error, buttonTitle: "확인")
+            }
         }
     }
 }

--- a/Projects/Features/MyPage/Sources/MyPage/MyPageView.swift
+++ b/Projects/Features/MyPage/Sources/MyPage/MyPageView.swift
@@ -264,6 +264,7 @@ extension MyPageFeature.AlertCase: AlertPresentable {
     public var alertInfo: AlertInfo {
         switch self {
         case .authorization: return .authorization
+        case .error(.noInternet): return .noInternet
         case .error: return .error
         }
     }

--- a/Projects/Features/MyPage/Sources/MyPage/MyPageView.swift
+++ b/Projects/Features/MyPage/Sources/MyPage/MyPageView.swift
@@ -144,7 +144,6 @@ private extension MyPageView {
                     Text(String(count))
                         .pretendard(style: .title2)
                         .foregroundStyle(Color.point1)
-                        .opacity(store.isLoading ? 0 : 1)
                 }
                 
                 Text(title)
@@ -191,7 +190,7 @@ private extension MyPageView {
                 }
             )
             .tint(Color.point1)
-            .renderedIf(!store.isLoading)
+            .disabled(store.isLoading)
         }
         .frame(height: 64)
         .padding(.horizontal, 16)

--- a/Projects/Features/MyPage/Sources/SubscribedFestivals/SubscribedFestivalsFeature.swift
+++ b/Projects/Features/MyPage/Sources/SubscribedFestivals/SubscribedFestivalsFeature.swift
@@ -20,7 +20,15 @@ public struct SubscribedFestivalsFeature {
     public enum AlertCase: Equatable {
         case authorization
         case agreement
-        case error(NetworkError.ErrorType)
+        case failedToFetch(NetworkError)
+        case failedToUpdate(NetworkError)
+        
+        var canDismiss: Bool {
+            switch self {
+            case .failedToFetch: return false
+            default: return true
+            }
+        }
     }
     
     @ObservableState
@@ -47,7 +55,6 @@ public struct SubscribedFestivalsFeature {
         case noticiationButtonTapped(Festival)
         case notificationAgreementUpdated(Bool)
         case notificationUpdated(Int)
-        case showError(NetworkError?)
         case showAlert(AlertCase)
         case backButtonTapped
         case navigateToFestival(Festival, Bool)
@@ -102,7 +109,7 @@ public struct SubscribedFestivalsFeature {
                 
                 if !isEnabled {
                     return .run { send in
-                        await send(updateNotificaion(festival.id, isEnabled: isEnabled))
+                        await updateNotificaion(send, festival.id, isEnabled)
                     }
                 }
                 
@@ -112,7 +119,7 @@ public struct SubscribedFestivalsFeature {
                     return .send(.showAlert(.agreement))
                 } else {
                     return .run { send in
-                        await send(updateNotificaion(festival.id, isEnabled: isEnabled))
+                        await updateNotificaion(send, festival.id, isEnabled)
                     }
                 }
             case .notificationUpdated(let id):
@@ -123,18 +130,17 @@ public struct SubscribedFestivalsFeature {
             case .notificationAgreementUpdated(let isAccepted):
                 state.isAccepted = isAccepted
                 return .none
-            case .showError(let networkError):
-                guard let networkError else { return .none }
-                return .send(.showAlert(.error(networkError.type)))
             case .showAlert(let alertCase):
                 state.isLoading = false
-                state.alert = .init(alertCase)
+                state.alert = .init(alertCase, alertCase.canDismiss)
                 return .none
             case .alert(.presented(.buttonTapped(.authorization))):
                 state.hasTappedButton = true
                 state.shouldOpenURL = true
                 return .none
             case .alert(.presented(.buttonTapped(.agreement))):
+                return .send(.backButtonTapped)
+            case .alert(.presented(.buttonTapped(.failedToFetch))):
                 return .send(.backButtonTapped)
             case .alert: return .none
             case .backButtonTapped:
@@ -165,7 +171,8 @@ private extension SubscribedFestivalsFeature {
             await send(.authorizationChecked(isAuthorized))
         } catch {
             let networkError = error as? NetworkError
-            await send(.showError(networkError))
+            guard let networkError else { return }
+            await send(.showAlert(.failedToFetch(networkError)))
         }
     }
     
@@ -177,18 +184,24 @@ private extension SubscribedFestivalsFeature {
         return try await notificationUseCase.fetchNotificationState()
     }
     
-    func updateNotificaion(_ id: Int, isEnabled: Bool) async -> Action {
+    func updateNotificaion(
+        _ send: Send<Action>,
+        _ id: Int,
+        _ isEnabled: Bool
+    ) async {
         do {
             let isAuthorized = await isAuthorized
             if !isAuthorized, isEnabled {
-                return .showAlert(.authorization)
+                await(send(.showAlert(.authorization)))
+                return
             }
             
             try await notificationUseCase.updateNotification(id: id, isEnabled: isEnabled)
-            return .notificationUpdated(id)
+            await send(.notificationUpdated(id))
         } catch {
             let networkError = error as? NetworkError
-            return .showError(networkError)
+            guard let networkError else { return }
+            await send(.showAlert(.failedToUpdate(networkError)))
         }
     }
     
@@ -198,7 +211,8 @@ private extension SubscribedFestivalsFeature {
             await send(.notificationAgreementUpdated(isEnabled))
         } catch {
             let networkError = error as? NetworkError
-            await send(.showError(networkError))
+            guard let networkError else { return }
+            await send(.showAlert(.failedToUpdate(networkError)))
         }
     }
     

--- a/Projects/Features/MyPage/Sources/SubscribedFestivals/SubscribedFestivalsFeature.swift
+++ b/Projects/Features/MyPage/Sources/SubscribedFestivals/SubscribedFestivalsFeature.swift
@@ -17,10 +17,10 @@ public struct SubscribedFestivalsFeature {
     @Dependency(\.festivalUseCase) private var festivalUseCase
     @Dependency(\.notificationUseCase) private var notificationUseCase
     
-    public enum AlertCase: CaseIterable {
+    public enum AlertCase: Equatable {
         case authorization
         case agreement
-        case error
+        case error(NetworkError.ErrorType)
     }
     
     @ObservableState
@@ -47,6 +47,7 @@ public struct SubscribedFestivalsFeature {
         case noticiationButtonTapped(Festival)
         case notificationAgreementUpdated(Bool)
         case notificationUpdated(Int)
+        case showError(NetworkError?)
         case showAlert(AlertCase)
         case backButtonTapped
         case navigateToFestival(Festival, Bool)
@@ -122,6 +123,9 @@ public struct SubscribedFestivalsFeature {
             case .notificationAgreementUpdated(let isAccepted):
                 state.isAccepted = isAccepted
                 return .none
+            case .showError(let networkError):
+                guard let networkError else { return .none }
+                return .send(.showAlert(.error(networkError.type)))
             case .showAlert(let alertCase):
                 state.isLoading = false
                 state.alert = .init(alertCase)
@@ -160,7 +164,8 @@ private extension SubscribedFestivalsFeature {
             try await send(.notificationStateFetched(isAccepted))
             await send(.authorizationChecked(isAuthorized))
         } catch {
-            await send(.showAlert(.error))
+            let networkError = error as? NetworkError
+            await send(.showError(networkError))
         }
     }
     
@@ -182,7 +187,8 @@ private extension SubscribedFestivalsFeature {
             try await notificationUseCase.updateNotification(id: id, isEnabled: isEnabled)
             return .notificationUpdated(id)
         } catch {
-            return .showAlert(.error)
+            let networkError = error as? NetworkError
+            return .showError(networkError)
         }
     }
     
@@ -191,7 +197,8 @@ private extension SubscribedFestivalsFeature {
             try await notificationUseCase.updateNotification(isEnabled: isEnabled)
             await send(.notificationAgreementUpdated(isEnabled))
         } catch {
-            await send(.showAlert(.error))
+            let networkError = error as? NetworkError
+            await send(.showError(networkError))
         }
     }
     

--- a/Projects/Features/MyPage/Sources/SubscribedFestivals/SubscribedFestivalsView.swift
+++ b/Projects/Features/MyPage/Sources/SubscribedFestivals/SubscribedFestivalsView.swift
@@ -55,10 +55,17 @@ public struct SubscribedFestivalsView: View {
 extension SubscribedFestivalsFeature.AlertCase: AlertPresentable {
     public var alertInfo: AlertInfo {
         switch self {
-        case .error(.noInternet): return .noInternet
-        case .error: return .error
         case .authorization: return .authorization
         case .agreement: return .agreement
+        case .failedToFetch(let error): return alertInfo(error)
+        case .failedToUpdate(let error): return alertInfo(error)
+        }
+    }
+    
+    private func alertInfo(_ error: NetworkError) -> AlertInfo {
+        switch error.type {
+        case .noInternet: .noInternet
+        default: .error(error, buttonTitle: "확인")
         }
     }
 }

--- a/Projects/Features/MyPage/Sources/SubscribedFestivals/SubscribedFestivalsView.swift
+++ b/Projects/Features/MyPage/Sources/SubscribedFestivals/SubscribedFestivalsView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import ComposableArchitecture
 import DesignSystem
 import Base
+import Domain
 
 public struct SubscribedFestivalsView: View {
     @Bindable private var store: StoreOf<SubscribedFestivalsFeature>
@@ -54,6 +55,7 @@ public struct SubscribedFestivalsView: View {
 extension SubscribedFestivalsFeature.AlertCase: AlertPresentable {
     public var alertInfo: AlertInfo {
         switch self {
+        case .error(.noInternet): return .noInternet
         case .error: return .error
         case .authorization: return .authorization
         case .agreement: return .agreement

--- a/Projects/Features/Root/Sources/Main/MainFeature.swift
+++ b/Projects/Features/Root/Sources/Main/MainFeature.swift
@@ -39,6 +39,7 @@ public struct MainFeature {
         case binding(BindingAction<State>)
         case path(StackActionOf<Path>)
         case navigateToFestival(Festival, Bool)
+        case showError(NetworkError?)
         case showAlert(AlertCase)
         case alert(PresentationAction<CustomAlert<AlertCase>.Action>)
     }
@@ -122,6 +123,9 @@ public struct MainFeature {
                     return .none
                 default: return .none
                 }
+            case .showError(let networkError):
+                guard let networkError else { return .none }
+                return .send(.showAlert(.error(networkError.type)))
             case .showAlert(let alertCase):
                 state.alert = .init(alertCase)
                 return .none
@@ -170,7 +174,8 @@ private extension MainFeature {
             let festival = try await festivalUseCase.fetchFestival(id: id)
             return .navigateToFestival(festival, isFavorite)
         } catch {
-            return .showAlert(.error)
+            let networkError = error as? NetworkError
+            return .showError(networkError)
         }
     }
 }
@@ -198,7 +203,7 @@ extension MainFeature {
     }
     
     public enum AlertCase: Equatable {
-        case error
+        case error(NetworkError.ErrorType)
         case home(HomeFeature.AlertCase)
     }
 }

--- a/Projects/Features/Root/Sources/Main/MainFeature.swift
+++ b/Projects/Features/Root/Sources/Main/MainFeature.swift
@@ -125,10 +125,12 @@ public struct MainFeature {
                 }
             case .showError(let networkError):
                 guard let networkError else { return .none }
-                return .send(.showAlert(.error(networkError.type)))
+                return .send(.showAlert(.error(networkError)))
             case .showAlert(let alertCase):
-                state.alert = .init(alertCase)
+                state.alert = .init(alertCase, alertCase.canDismiss)
                 return .none
+            case .alert(.presented(.buttonTapped(.home))):
+                return .send(.home(.onRefresh))
             case .navigateToFestival(let festival, let isFavorite):
                 UserDefaults.festivalID = nil
                 state.path.append(.festival(.init(
@@ -203,7 +205,14 @@ extension MainFeature {
     }
     
     public enum AlertCase: Equatable {
-        case error(NetworkError.ErrorType)
+        case error(NetworkError)
         case home(HomeFeature.AlertCase)
+        
+        var canDismiss: Bool {
+            switch self {
+            case .error: return true
+            case .home: return false
+            }
+        }
     }
 }

--- a/Projects/Features/Root/Sources/Main/MainView.swift
+++ b/Projects/Features/Root/Sources/Main/MainView.swift
@@ -129,9 +129,13 @@ private extension MainView {
 
 extension MainFeature.AlertCase: AlertPresentable {
     public var alertInfo: AlertInfo {
-        return switch self {
-        case .home(let alertCase): alertCase.alertInfo
-        case .error: .error
+        switch self {
+        case .home(let alertCase): return alertCase.alertInfo
+        case .error(let error):
+            switch error.type {
+            case .noInternet: return .noInternet
+            default: return .error(error, buttonTitle: "확인")
+            }
         }
     }
 }

--- a/Projects/Network/Sources/Extensions/Logger+.swift
+++ b/Projects/Network/Sources/Extensions/Logger+.swift
@@ -9,6 +9,7 @@
 import OSLog
 import Util
 import Data
+import Domain
 
 extension Logger {
     private static let network = Logger(subsystem: Bundle.identifier, category: "Network")

--- a/Projects/Network/Sources/NetworkService/NetworkService.swift
+++ b/Projects/Network/Sources/NetworkService/NetworkService.swift
@@ -9,6 +9,7 @@
 import Foundation
 import OSLog
 import Data
+import Domain
 
 public struct NetworkService: NetworkServiceProtocol {
     public init() {}
@@ -75,6 +76,7 @@ private extension NetworkService {
     func networkError(_ error: URLError) -> NetworkError {
         let message = error.localizedDescription
         let type: NetworkError.ErrorType = switch error.code {
+        case .notConnectedToInternet: .noInternet
         case .networkConnectionLost, .timedOut: .timeout
         default: .others
         }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호를 명시하세요 (예: Closes #123, Resolves #45) -->
- https://darayos2.atlassian.net/browse/FSTB-119

---

## ✨ 작업 내용
<!-- 어떤 기능/버그/리팩토링 작업을 했는지 간단하게 작성해주세요 -->
- 화면설계서 알림 로직에 따라 배경 터치시 해제 여부, 버튼 터치 동작, X 버튼 유무 등을 달리 구현

